### PR TITLE
Automate building release binaries

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,93 @@
+name: Release (MacOS, Linux)
+
+on:
+  release:
+    types:
+      - created
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: Deploy for ${{ matrix.os }}
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        name: [linux-18, linux-20, linux-22, macos-10.15, macos-11]
+
+        include:
+          - name: linux-18
+            os: ubuntu-18.04
+            artifact_name: poi-radio
+            asset_name: poi-radio
+          - name: linux-20
+            os: ubuntu-20.04
+            artifact_name: poi-radio
+            asset_name: poi-radio
+          - name: linux-22
+            os: ubuntu-22.04
+            artifact_name: poi-radio
+            asset_name: poi-radio
+          - name: macos-10.15
+            os: macos-10.15
+            artifact_name: poi-radio
+            asset_name: poi-radio
+          - name: macos-11
+            os: macos-11
+            artifact_name: poi-radio
+            asset_name: poi-radio
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        run: cargo build --release && mv target/release/${{ matrix.artifact_name }} target/release/${{ matrix.asset_name }}
+
+      - name: Upload binaries to release
+        run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token && gh release upload ${GITHUB_REF##*/} target/release/${{ matrix.asset_name }}
+
+name: Release (MacOS M1)
+
+on:
+  release:
+    types:
+      - created
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  deploy:
+    name: Deploy for macos (M1)
+    if: startsWith(github.ref, 'refs/tags')
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        name: [macos-m1]
+
+        include:
+          - name: macos-m1
+            os: macos-11
+            artifact_name: poi-radio
+            asset_name: poi-radio
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+
+      - name: Build
+        run: rustup target add aarch64-apple-darwin && cargo build --release --target aarch64-apple-darwin && mv target/aarch64-apple-darwin/release/${{ matrix.artifact_name }} target/release/${{ matrix.asset_name }}
+
+      - name: Upload poi-radio to release
+        run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token && gh release upload ${GITHUB_REF##*/} target/release/${{ matrix.asset_name }}


### PR DESCRIPTION
The added workflow yaml file builds a release for all targets specified in it:
`[linux-18, linux-20, linux-22, macos-10.15, macos-11, macos-m1]`

It triggers on manual Release creation.