### PR TITLE
refactor: improve Dockerfile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "poi-radio"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", rev="d302f25" }
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 waku = { package = "waku-bindings", git = "https://github.com/waku-org/waku-rust-bindings", rev="0fb4e2e" }
 prost = "0.11"
 once_cell = "1.15"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:buster-slim
+FROM debian:latest
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
@@ -9,20 +9,20 @@ RUN apt-get update \
         libssl-dev \
         clang \
         build-essential \
-    && apt-get clean \  
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
+
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o rustup-init.sh \
 && sh rustup-init.sh -y --default-toolchain stable --no-modify-path
 ENV PATH="/root/.cargo/bin:${PATH}" 
 
-RUN wget https://golang.org/dl/go1.19.5.linux-arm64.tar.gz \
-    && tar -C /usr/local -xzf go1.19.5.linux-arm64.tar.gz
-ENV PATH=$PATH:/usr/local/go/bin
-
 COPY . /poi-radio
 WORKDIR /poi-radio
 
+RUN sh install-golang.sh
+ENV PATH=$PATH:/usr/local/go/bin
+
 RUN cargo build
-CMD ["cargo", "run"]
+CMD ["cargo", "run", "boot"]

--- a/README.md
+++ b/README.md
@@ -1,26 +1,10 @@
 # POI-Crosschecker Radio
 
+[![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.graphops.xyz/graphcast/radios/poi-radio)
+
+## Introduction
+
 The key requirement for an Indexer to earn indexing rewards is to submit a valid Proof of Indexing (POI) promptly. The importance of valid POIs causes many Indexers to alert each other on subgraph health in community discussions. To alleviate the Indexer workload, this Radio utilized Graphcast SDK to exchange and aggregate POI along with a list of Indexer on-chain identities that can be used to trace reputations. With the pubsub pattern, the Indexer can get notified as soon as other indexers (with majority of stake) publish a POI different from the local POI.
-
-## 🏃 Quickstart
-
-📝 **As prerequisites to running the POI cross-checker, make sure that**:
-
-1. You have registered a Graphcast operator address. You can connect a operator address to your indexer address (with a 1:1 relationship) using our very own [Registry contract](https://goerli.etherscan.io/address/0x1e408c2cf66fd3afcea0f49dc44c9f4db5575e79) (on Goerli).
-2. You have **graph-node** syncing your indexer's onchain allocations.
-3. You have exported the environment variables including `GRAPH_NODE_STATUS_ENDPOINT`, `PRIVATE_KEY` for operator wallet, `ETH_NODE` block provider. 
-4. Optionally, provide `SLACK_TOKEN` and `SLACK_WEBHOOK` for POI divergence notifications, and `WAKU_HOST` and `WAKU_PORT` for radio's gossip node instance.
-5. Have [Rust](https://www.rust-lang.org/tools/install) installed globally.
-
-If there's no other peer subscribed to a topic you are interested in, start up a boot node
-```
-cargo run boot
-```
-
-With different `WAKU_PORT`s, you can start other instances with
-```
-cargo run
-```
 
 ## 🧪 Testing
 
@@ -30,13 +14,11 @@ To run unit tests for the Radio. We recommend using [nextest](https://nexte.st/)
 cargo nextest run
 ```
 
-#### 🔃 Workflow
+There's also integration tests, which you can run with the included bash script:
 
-When an Indexer runs the POI cross-checker, they immediately start listening for new blocks on Ethereum. On a certain interval the Radio fetches all the allocations of that Indexer and saves a list of the IPFS hashes of the subgraphs that the Indexer is allocating to. Right after that we loop through the list and send a request for a normalised POI for each subgraph (using the metadata of the block that we're on) and save those POIs in an in-memopry map, below we will refer to these POIs as _local_ POIs since they are the ones that we've generated.
-
-At the same time, other Indexers running the Radio will start doing the same, which means that messages start propagating through the network. We handle each message and add the POI from it in another in-memory map, we can refer to these POIs as _remote_ POIs since these are the ones that we've received from other network participants. The messages don't come only with the POI and subgraph hash, they also include a nonce (UNIX timestamp), block number and signature. The signature is then used to derive the sender's on-chain Indexer address. It's important to note that before saving an entry to the map, we send a request for the sender's on-chain stake, which will be used later for sorting the entries.
-
-After another interval we compare our _local_ POIs with the _remote_ ones. We sort the remote ones so that for each subgraph (on each block) we can take the POI that is backed by the most on-chain stake (❗ This does not mean the one that is sent by the Indexer with the highest stake, but rather the one that has the most **combined** stake of all the Indexers that attested to it). After we have that top POI, we compare it with our _local_ POI for that subgraph at that block. Voilà! We now know whether our POI matches with the current consensus on the network.
+```
+sh run-tests.sh
+```
 
 ## Contributing
 

--- a/install-golang.sh
+++ b/install-golang.sh
@@ -1,0 +1,7 @@
+if [ $(uname -m) = "aarch64" ]; then
+    wget https://golang.org/dl/go1.19.5.linux-arm64.tar.gz &&
+        tar -C /usr/local -xzf go1.19.5.linux-arm64.tar.gz
+else
+    wget https://golang.org/dl/go1.19.5.linux-amd64.tar.gz &&
+        tar -C /usr/local -xzf go1.19.5.linux-amd64.tar.gz
+fi

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ async fn main() {
         None,
         waku_host,
         waku_port,
+        None,
     )
     .await
     .unwrap();
@@ -247,6 +248,7 @@ mod tests {
             &(mock_server.uri() + "/gossip-registry-test"),
             &(mock_server.uri() + "/network-subgraph"),
             Some(vec!["some-hash"]),
+            None,
             None,
             None,
         )


### PR DESCRIPTION
The current `Dockerfile` in `main` does not work on host machines running `amd` architectures (it would only work if the `Dockerfile` is used on MacOS, not Linux).

With these updates, it should work no matter what the host machine is, it should be OS and architecture agnostic.

The main issue was the Go binary, since it requires a different binary for different operating systems and architectures.

Has been tested on MacOS and Debian.
