### PR TITLE
subgraph indexing network specific POI query

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
         # These are peer deps of Cargo and should not be automatically bumped
         - dependency-name: "semver"
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'daily'
+      interval: 'weekly'
     commit-message:
       prefix: chore
       include: scope

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,14 @@
+{
+  "types": [
+    { "type": "feat", "section": "Features" },
+    { "type": "fix", "section": "Bug Fixes" },
+    { "type": "chore", "hidden": true },
+    { "type": "docs", "hidden": true },
+    { "type": "style", "hidden": true },
+    { "type": "refactor", "hidden": true },
+    { "type": "perf", "hidden": true },
+    { "type": "test", "hidden": true }
+  ],
+  "commitUrlFormat": "https://github.com/mokkapps/changelog-generator-demo/commits/{{hash}}",
+  "compareUrlFormat": "https://github.com/mokkapps/changelog-generator-demo/compare/{{previousTag}}...{{currentTag}}"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,17 @@
 [package]
 name = "poi-radio"
-version = "0.0.1"
+version = "0.0.4"
 edition = "2021"
+authors = ["GraphOps (axiomatic-aardvark, hopeyen)"]
+description="POI Radio monitors subgraph data integrity in real time using Graphcast SDK"
+license="Apache-2.0"
+repository="https://github.com/graphops/poi-radio"
+keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
+categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
-waku = { package = "waku-bindings", git = "https://github.com/waku-org/waku-rust-bindings", rev="0fb4e2e" }
+graphcast-sdk = "0.0.5"
+waku = { package = "waku-bindings", version="0.1.0-beta3" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
@@ -18,7 +24,6 @@ serde_derive = "1.0.114"
 reqwest = { version = "0.11.0", features = ["json"] }
 ethers = "1.0.0"
 regex = "1.7.1"
-lazy_static = "1.4.0"
 ethers-contract = "1.0.0"
 ethers-core = "1.0.0"
 ethers-derive-eip712 = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.0.5"
-waku = { package = "waku-bindings", version="0.1.0-beta3" }
+graphcast_sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ serde_derive = "1.0.114"
 reqwest = { version = "0.11.0", features = ["json"] }
 ethers = "1.0.0"
 regex = "1.7.1"
+lazy_static = "1.4.0"
 ethers-contract = "1.0.0"
 ethers-core = "1.0.0"
 ethers-derive-eip712 = "1.0.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # POI-Crosschecker Radio
 
 [![Docs](https://img.shields.io/badge/docs-latest-brightgreen.svg)](https://docs.graphops.xyz/graphcast/radios/poi-radio)
+[![crates.io](https://img.shields.io/crates/v/graphcast-sdk.svg)](https://crates.io/crates/poi-radio)
 
 ## Introduction
 

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,16 +1,32 @@
+// Maybe later on move graphql to SDK as the queries are pretty standarded
 use graphcast_sdk::graphql::QueryError;
 use graphql_client::{GraphQLQuery, Response};
 use serde_derive::{Deserialize, Serialize};
 
 /// Derived GraphQL Query to Proof of Indexing
-//TODO: refactor ProofOfIndexing typing for build query
 #[derive(GraphQLQuery, Serialize, Deserialize, Debug)]
 #[graphql(
-    schema_path = "src/graphql/schema_proof_of_indexing.graphql",
+    schema_path = "src/graphql/schema_graph_node.graphql",
     query_path = "src/graphql/query_proof_of_indexing.graphql",
     response_derives = "Debug, Serialize, Deserialize"
 )]
 pub struct ProofOfIndexing;
+
+#[derive(GraphQLQuery, Serialize, Deserialize, Debug, Clone)]
+#[graphql(
+    schema_path = "src/graphql/schema_graph_node.graphql",
+    query_path = "src/graphql/query_indexing_statuses.graphql",
+    response_derives = "Debug, Serialize, Deserialize, Clone"
+)]
+pub struct IndexingStatuses;
+
+#[derive(GraphQLQuery, Serialize, Deserialize, Debug)]
+#[graphql(
+    schema_path = "src/graphql/schema_graph_node.graphql",
+    query_path = "src/graphql/query_block_hash_from_number.graphql",
+    response_derives = "Debug, Serialize, Deserialize"
+)]
+pub struct BlockHashFromNumber;
 
 /// Query graph node for Proof of Indexing
 pub async fn perform_proof_of_indexing(
@@ -47,6 +63,85 @@ pub async fn query_graph_node_poi(
     if let Some(data) = response_body.data {
         match data.proof_of_indexing {
             Some(poi) => Ok(poi),
+            _ => Err(QueryError::EmptyResponseError),
+        }
+    } else {
+        Err(QueryError::EmptyResponseError)
+    }
+}
+
+/// Query graph node for Indexing Statuses
+pub async fn perform_indexing_statuses(
+    graph_node_endpoint: String,
+    variables: indexing_statuses::Variables,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let request_body = IndexingStatuses::build_query(variables);
+    let client = reqwest::Client::new();
+    client
+        .post(graph_node_endpoint)
+        .json(&request_body)
+        .send()
+        .await?
+        .error_for_status()
+}
+
+/// Construct GraphQL variables and parse result for Proof of Indexing.
+/// For other radio use cases, provide a function that returns a string
+pub async fn query_graph_node_deployment_network(
+    graph_node_endpoint: String,
+    ipfs_hash: String,
+) -> Result<String, QueryError> {
+    let variables: indexing_statuses::Variables = indexing_statuses::Variables {
+        deployments: vec![ipfs_hash.clone()],
+    };
+    let queried_result = perform_indexing_statuses(graph_node_endpoint.clone(), variables).await?;
+    let response_body: Response<indexing_statuses::ResponseData> = queried_result.json().await?;
+
+    response_body
+        .data
+        .and_then(|data| {
+            data.indexing_statuses
+                .first()
+                .and_then(|status| status.chains.first())
+                .map(|chain| chain.network.clone())
+        })
+        .ok_or(QueryError::IndexingError)
+}
+
+/// Query graph node for Block hash
+pub async fn perform_block_hash_from_number(
+    graph_node_endpoint: String,
+    variables: block_hash_from_number::Variables,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let request_body = BlockHashFromNumber::build_query(variables);
+    let client = reqwest::Client::new();
+    client
+        .post(graph_node_endpoint)
+        .json(&request_body)
+        .send()
+        .await?
+        .error_for_status()
+}
+
+/// Construct GraphQL variables and parse result for Proof of Indexing.
+/// For other radio use cases, provide a function that returns a string
+pub async fn query_graph_node_network_block_hash(
+    graph_node_endpoint: String,
+    network: String,
+    block_number: i64,
+) -> Result<String, QueryError> {
+    let variables: block_hash_from_number::Variables = block_hash_from_number::Variables {
+        network,
+        block_number,
+    };
+    let queried_result =
+        perform_block_hash_from_number(graph_node_endpoint.clone(), variables).await?;
+    let response_body: Response<block_hash_from_number::ResponseData> =
+        queried_result.json().await?;
+
+    if let Some(data) = response_body.data {
+        match data.block_hash_from_number {
+            Some(hash) => Ok(hash),
             _ => Err(QueryError::EmptyResponseError),
         }
     } else {

--- a/src/graphql/query_block_hash_from_number.graphql
+++ b/src/graphql/query_block_hash_from_number.graphql
@@ -1,0 +1,6 @@
+query BlockHashFromNumber($network: String!, $blockNumber: Int!) {
+    blockHashFromNumber(
+      network: $network
+      blockNumber: $blockNumber
+    )
+}

--- a/src/graphql/query_indexing_statuses.graphql
+++ b/src/graphql/query_indexing_statuses.graphql
@@ -1,0 +1,22 @@
+query IndexingStatuses($deployments: [String!]!) {
+  indexingStatuses(subgraphs: $deployments) {
+    subgraph
+    synced
+    health
+    fatalError {
+      handler
+      message
+    }
+    chains {
+      network
+      latestBlock {
+        number
+        hash
+      }
+      chainHeadBlock {
+        number
+        hash
+      }
+    }
+  }
+}

--- a/src/graphql/schema_graph_node.graphql
+++ b/src/graphql/schema_graph_node.graphql
@@ -1,0 +1,39 @@
+type BlockPointer {
+  number: String!
+  hash: String!
+}
+                                                                                                                                                                                                                                                        
+type IndexingError {
+  handler: String
+  message: String!
+}
+
+type ChainIndexingStatus {
+  network: String!
+  latestBlock: BlockPointer
+  chainHeadBlock: BlockPointer
+}
+
+type IndexerDeployment {
+  subgraph: String!
+  synced: Boolean!
+  health: String!
+  fatalError: IndexingError
+  chains: [ChainIndexingStatus!]!
+}
+
+type Query {
+  indexingStatuses(
+    subgraphs: [String!]!
+  ): [IndexerDeployment!]!
+  proofOfIndexing(
+    subgraph: String!
+    blockNumber: Int!
+    blockHash: String!
+    indexer: String
+  ): String
+  blockHashFromNumber(
+    network: String!
+    blockNumber: Int!
+  ): String
+}

--- a/src/graphql/schema_proof_of_indexing.graphql
+++ b/src/graphql/schema_proof_of_indexing.graphql
@@ -1,8 +1,0 @@
-type Query {
-    proofOfIndexing(
-      subgraph: String!
-      blockNumber: Int!
-      blockHash: String!
-      indexer: String
-    ): String
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,12 @@ use colored::*;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
-use lazy_static::lazy_static;
 use num_bigint::BigUint;
+use once_cell::sync::Lazy;
 use once_cell::sync::OnceCell;
 use prost::Message;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::{
     collections::HashMap,
     error::Error,
@@ -51,24 +52,114 @@ impl RadioPayloadMessage {
     }
 }
 
-// Maybe move to SDK
-lazy_static! {
-    pub static ref SUPPORTED_NETWORK_INTERVALS: HashMap<&'static str, u64> = [
-        ("goerli", 2),
-        ("mainnet", 10),
-        ("gnosis", 5),
-        ("hardhat", 5),
-        ("arbitrum-one", 5),
-        ("arbitrum-goerli", 5),
-        ("avalanche", 5),
-        ("polygon", 5),
-        ("celo", 5),
-        ("optimism", 5),
-    ]
-    .iter()
-    .cloned()
-    .collect();
+#[derive(Debug, Clone)]
+pub struct Network {
+    pub name: NetworkName,
+    pub interval: u64,
 }
+
+pub struct BlockClock {
+    pub current_block: u64,
+    pub compare_block: u64,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum NetworkName {
+    Goerli,
+    Mainnet,
+    Gnosis,
+    Hardhat,
+    ArbitrumOne,
+    ArbitrumGoerli,
+    Avalanche,
+    Polygon,
+    Celo,
+    Optimism,
+    Unknown,
+}
+
+impl NetworkName {
+    pub fn from_string(name: &str) -> Self {
+        match name {
+            "goerli" => NetworkName::Goerli,
+            "mainnet" => NetworkName::Mainnet,
+            "gnosis" => NetworkName::Gnosis,
+            "hardhat" => NetworkName::Hardhat,
+            "arbitrum-one" => NetworkName::ArbitrumOne,
+            "arbitrum-goerli" => NetworkName::ArbitrumGoerli,
+            "avalanche" => NetworkName::Avalanche,
+            "polygon" => NetworkName::Polygon,
+            "celo" => NetworkName::Celo,
+            "optimism" => NetworkName::Optimism,
+            _ => NetworkName::Unknown,
+        }
+    }
+}
+
+impl fmt::Display for NetworkName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            NetworkName::Goerli => "goerli",
+            NetworkName::Mainnet => "mainnet",
+            NetworkName::Gnosis => "gnosis",
+            NetworkName::Hardhat => "hardhat",
+            NetworkName::ArbitrumOne => "arbitrum-one",
+            NetworkName::ArbitrumGoerli => "arbitrum-goerli",
+            NetworkName::Avalanche => "avalanche",
+            NetworkName::Polygon => "polygon",
+            NetworkName::Celo => "celo",
+            NetworkName::Optimism => "optimism",
+            NetworkName::Unknown => "unknown",
+        };
+
+        write!(f, "{name}")
+    }
+}
+
+pub static NETWORKS: Lazy<Vec<Network>> = Lazy::new(|| {
+    vec![
+        Network {
+            name: NetworkName::from_string("goerli"),
+            interval: 2,
+        },
+        Network {
+            name: NetworkName::from_string("mainnet"),
+            interval: 10,
+        },
+        Network {
+            name: NetworkName::from_string("gnosis"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("hardhat"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("arbitrum-one"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("arbitrum-goerli"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("avalanche"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("polygon"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("celo"),
+            interval: 5,
+        },
+        Network {
+            name: NetworkName::from_string("optimism"),
+            interval: 5,
+        },
+    ]
+});
 
 pub type RemoteAttestationsMap = HashMap<String, HashMap<u64, Vec<Attestation>>>;
 pub type LocalAttestationsMap = HashMap<String, HashMap<u64, Attestation>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,20 @@
+use anyhow::anyhow;
+use colored::*;
+use ethers_contract::EthAbiType;
+use ethers_core::types::transaction::eip712::Eip712;
+use ethers_derive_eip712::*;
+use lazy_static::lazy_static;
+use num_bigint::BigUint;
+use once_cell::sync::OnceCell;
+use prost::Message;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::HashMap,
     error::Error,
     sync::{Arc, Mutex},
 };
 use tokio::sync::Mutex as AsyncMutex;
+use tracing::error;
 
 use graphcast_sdk::{
     graphcast_agent::{
@@ -12,17 +23,6 @@ use graphcast_sdk::{
     },
     graphql::{client_network::query_network_subgraph, client_registry::query_registry_indexer},
 };
-use num_bigint::BigUint;
-use once_cell::sync::OnceCell;
-
-use anyhow::anyhow;
-use colored::*;
-use ethers_contract::EthAbiType;
-use ethers_core::types::transaction::eip712::Eip712;
-use ethers_derive_eip712::*;
-use prost::Message;
-use serde::{Deserialize, Serialize};
-use tracing::error;
 
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize)]
 #[eip712(
@@ -49,6 +49,25 @@ impl RadioPayloadMessage {
     pub fn payload_content(&self) -> String {
         self.content.clone()
     }
+}
+
+// Maybe move to SDK
+lazy_static! {
+    pub static ref SUPPORTED_NETWORK_INTERVALS: HashMap<&'static str, u64> = [
+        ("goerli", 2),
+        ("mainnet", 10),
+        ("gnosis", 5),
+        ("hardhat", 5),
+        ("arbitrum-one", 5),
+        ("arbitrum-goerli", 5),
+        ("avalanche", 5),
+        ("polygon", 5),
+        ("celo", 5),
+        ("optimism", 5),
+    ]
+    .iter()
+    .cloned()
+    .collect();
 }
 
 pub type RemoteAttestationsMap = HashMap<String, HashMap<u64, Vec<Attestation>>>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ use num_bigint::BigUint;
 use num_traits::Zero;
 use poi_radio::{
     active_allocation_hashes, attestation_handler, compare_attestations, process_messages,
-    save_local_attestation, Attestation, LocalAttestationsMap, RadioPayloadMessage,
-    GRAPHCAST_AGENT, MESSAGES, SUPPORTED_NETWORK_INTERVALS,
+    save_local_attestation, Attestation, BlockClock, LocalAttestationsMap, NetworkName,
+    RadioPayloadMessage, GRAPHCAST_AGENT, MESSAGES, NETWORKS,
 };
 use std::collections::HashMap;
 use std::env;
@@ -58,20 +58,20 @@ async fn main() {
     // Send message every x blocks for which wait y blocks before attestations
     let wait_block_duration = 2;
 
-    let provider: Provider<Http> = Provider::<Http>::try_from(eth_node.clone()).unwrap();
-    // Initialize providers for indexing networks in the format of PROVIDER_[NETWORK]
-    let provider_endpoints: HashMap<&'static str, Option<Provider<Http>>> =
-        SUPPORTED_NETWORK_INTERVALS
-            .iter()
-            .map(|(&network, &_interval)| {
-                (
-                    network,
-                    env::var("PROVIDER_".to_string() + network.to_uppercase().as_str())
-                        .ok()
-                        .and_then(|endpoint| Provider::<Http>::try_from(endpoint).ok()),
-                )
-            })
-            .collect();
+    // Initialize providers for indexing networks in the format of PROVIDER_[NETWORK_NAME]
+    let provider_endpoints: HashMap<NetworkName, Option<Provider<Http>>> = NETWORKS
+        .iter()
+        .map(|n| {
+            let network_name = n.name;
+            (
+                network_name,
+                env::var("PROVIDER_".to_string() + &network_name.to_string().to_uppercase())
+                    .ok()
+                    .and_then(|endpoint| Provider::<Http>::try_from(endpoint).ok()),
+            )
+        })
+        .collect();
+
     let wallet = private_key.parse::<LocalWallet>().unwrap();
     let radio_name: &str = "poi-radio";
 
@@ -112,8 +112,7 @@ async fn main() {
         .register_handler(radio_handler)
         .expect("Could not register handler");
 
-    let mut curr_block = 0;
-    let mut compare_block: u64 = 0;
+    let mut block_store: HashMap<NetworkName, BlockClock> = HashMap::new();
 
     let local_attestations: Arc<Mutex<LocalAttestationsMap>> = Arc::new(Mutex::new(HashMap::new()));
 
@@ -133,53 +132,6 @@ async fn main() {
     // Main loop for sending messages, can factor out
     // and take radio specific query and parsing for radioPayload
     loop {
-        let block_number = U64::as_u64(&provider.get_block_number().await.unwrap()) - 5;
-
-        if curr_block == block_number {
-            sleep(Duration::from_secs(5));
-            continue;
-        }
-
-        debug!("{} {}", "🔗 Block number:".cyan(), block_number);
-        curr_block = block_number;
-
-        if block_number == compare_block {
-            debug!("{}", "Comparing attestations".magenta());
-
-            let remote_attestations = process_messages(
-                Arc::clone(MESSAGES.get().unwrap()),
-                &registry_subgraph,
-                &network_subgraph,
-            )
-            .await;
-            match remote_attestations {
-                Ok(remote_attestations) => {
-                    let mut messages = MESSAGES.get().unwrap().lock().unwrap();
-                    match compare_attestations(
-                        compare_block - wait_block_duration,
-                        remote_attestations,
-                        Arc::clone(&local_attestations),
-                    ) {
-                        Ok(msg) => {
-                            debug!("{}", msg.green().bold());
-                            messages.clear();
-                        }
-                        Err(err) => {
-                            error!("{}", err);
-                            messages.clear();
-                        }
-                    }
-                }
-                Err(err) => {
-                    error!(
-                        "{}{}",
-                        "An error occured while parsing messages: {}".red().bold(),
-                        err
-                    );
-                }
-            }
-        }
-
         // Radio specific message content query function
         // Function takes in an identifier string and make specific queries regarding the identifier
         // The example here combines a single function provided query endpoint, current block info based on the subgraph's indexing network
@@ -187,34 +139,122 @@ async fn main() {
         let identifiers = GRAPHCAST_AGENT.get().unwrap().content_identifiers();
         for id in identifiers {
             // Get the indexing network of the deployment
-            let network = match query_graph_node_deployment_network(
+            let network_name = match query_graph_node_deployment_network(
                 graph_node_endpoint.clone(),
                 id.clone(),
             )
             .await
             {
-                Ok(network) => network,
+                Ok(network) => NetworkName::from_string(&network),
                 Err(e) => {
                     warn!("Could not query for the subgraph's indexing network, check Graph node's indexing statuses of the deployment {}: {}", id.clone(), e);
+                    sleep(Duration::from_secs(1));
                     continue;
                 }
             };
 
+            let provider_name = format!("PROVIDER_{}", network_name.to_string().to_uppercase());
+            let indexing_network_provider = if let Some(provider) =
+                provider_endpoints.get(&network_name)
+            {
+                provider.as_ref().unwrap()
+            } else {
+                error!(
+                    "Missing a block provider for the indexing network {}, please provide one named `{}`",
+                    network_name,
+                    provider_name
+                );
+                sleep(Duration::from_secs(1));
+                continue;
+            };
+
+            let block_number = match indexing_network_provider.get_block_number().await {
+                Ok(n) => U64::as_u64(&n),
+                Err(err) => {
+                    error!(
+                        "Could not get block number on network {}, more info: {}",
+                        network_name.to_string(),
+                        err
+                    );
+                    sleep(Duration::from_secs(1));
+                    continue;
+                }
+            };
+
+            let block_clock = block_store
+                .entry(network_name)
+                .or_insert_with(|| BlockClock {
+                    current_block: 0,
+                    compare_block: 0,
+                });
+
+            if block_clock.current_block == block_number {
+                sleep(Duration::from_secs(5));
+                continue;
+            }
+
+            debug!("{} {}", "🔗 Block number:".cyan(), block_number);
+            block_clock.current_block = block_number;
+
+            if block_number == block_clock.compare_block {
+                debug!("{}", "Comparing attestations".magenta());
+
+                let remote_attestations = process_messages(
+                    Arc::clone(MESSAGES.get().unwrap()),
+                    &registry_subgraph,
+                    &network_subgraph,
+                )
+                .await;
+                match remote_attestations {
+                    Ok(remote_attestations) => {
+                        let mut messages = MESSAGES.get().unwrap().lock().unwrap();
+                        match compare_attestations(
+                            block_clock.compare_block - wait_block_duration,
+                            remote_attestations,
+                            Arc::clone(&local_attestations),
+                        ) {
+                            Ok(msg) => {
+                                debug!("{}", msg.green().bold());
+                                messages.clear();
+                            }
+                            Err(err) => {
+                                error!("{}", err);
+                                messages.clear();
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        error!(
+                            "{}{}",
+                            "An error occured while parsing messages: {}".red().bold(),
+                            err
+                        );
+                    }
+                }
+            }
+
             let poi_query =
                 partial!( query_graph_node_poi => graph_node_endpoint.clone(), id.clone(), _, _);
-            // get the indexing network's block provider and consensus block
-            let indexing_network_provider: &Provider<Http> = provider_endpoints.get(&network[..]).unwrap_or_else(|| panic!("Missing a block provider for the indexing network {}, please provide one named `PROVIDER_{}`", network.clone(), network.clone().to_uppercase())).as_ref().expect("Could not make construct a valid provider");
-            let block_number =
-                U64::as_u64(&indexing_network_provider.get_block_number().await.unwrap()) - 5;
-            // Send POI message at a fixed frequency
-            let examination_frequency = SUPPORTED_NETWORK_INTERVALS.get(&network[..]).expect("Subgraph is indexing an unsupported network, please report an issue on https://github.com/graphops/graphcast-rs");
+
+            // Look for the matching network name and extract the interval
+            let examination_frequency = match NETWORKS
+                .iter()
+                .find(|n| n.name.to_string() == network_name.to_string())
+            {
+                Some(n) => n.interval,
+                None => {
+                    warn!("Subgraph is indexing an unsupported network, please report an issue on https://github.com/graphops/graphcast-rs");
+                    sleep(Duration::from_secs(1));
+                    continue;
+                }
+            };
+
             if block_number % examination_frequency == 0 {
-                //TODO: compare_block and attestation need to be network based
-                compare_block = block_number + wait_block_duration;
+                block_clock.compare_block = block_number + wait_block_duration;
                 // block number and hash can actually be queried from graph node, but need a deterministic consensus on block number
                 let block_hash = match query_graph_node_network_block_hash(
                     graph_node_endpoint.clone(),
-                    network.clone().to_lowercase(),
+                    network_name.to_string().to_lowercase(),
                     block_number.try_into().unwrap(),
                 )
                 .await


### PR DESCRIPTION
### Description
Reorder POI generation query
- Add `indexingStatuses` query to the graph node for the `network`.
- Based on the network returned, select the block provider provided by the user (`provider_endpoints`) to query for latest block number. This could be queried from the graph node directly but we are using the providers for deterministic send_message block consensus.
- Based on the network returned, select the block examination frequency in networks supported by the radio (`SUPPORTED_NETWORK_BLOCK_INTERVALS`).
- Query block hash from the graph node, with block provider as a fallback if failed (`blockHashFromNumber`).
- Query POI with network specific block number and block hash.

For the feature to work completely, I think we still need 
- Network specific `compare_block` instead of just one number.
- Testing the combination of subgraphs from several different networks.

Later we can refactor parts of the logic to the SDK. Also, we should review the ordering of queries for efficiency and minimal calls to block provider and graph node.

### Issue link (if applicable)
Partially resolves graphops/graphcast-sdk#88
