### PR TITLE
feat: use indexing status to query block info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "fd73109"}
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "bfb38e9"}
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"

--- a/src/graphql/query_indexing_statuses.graphql
+++ b/src/graphql/query_indexing_statuses.graphql
@@ -1,5 +1,5 @@
-query IndexingStatuses($deployments: [String!]!) {
-  indexingStatuses(subgraphs: $deployments) {
+query IndexingStatuses {
+  indexingStatuses {
     subgraph
     synced
     health

--- a/src/graphql/schema_graph_node.graphql
+++ b/src/graphql/schema_graph_node.graphql
@@ -23,9 +23,7 @@ type IndexerDeployment {
 }
 
 type Query {
-  indexingStatuses(
-    subgraphs: [String!]!
-  ): [IndexerDeployment!]!
+  indexingStatuses: [IndexerDeployment!]!
   proofOfIndexing(
     subgraph: String!
     blockNumber: Int!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,18 @@ pub struct Network {
     pub interval: u64,
 }
 
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct BlockPointer {
+    pub hash: String,
+    pub number: u64,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct SubgraphStatus {
+    pub network: String,
+    pub block: BlockPointer,
+}
+
 pub struct BlockClock {
     pub current_block: u64,
     pub compare_block: u64,


### PR DESCRIPTION
### Description
Move away from block provider based triggering to network monitor and syncing status from Graph node.

- added a query function that updates the network chainhead hashmap, and returns Subgraph: (network, latest_block) hashmap. (A bit complicated and can probably be refactored in the near future)
- Poll indexingStatuses every 5 seconds from graph node for the above hashmaps
- Match for network and the appropriate examination block, query POI on the examination block
- Removed block providers from the radio, it is still required for `GraphcastAgent` for signing messages and resolve GraphcastID address

### Issue link (if applicable)
Resolves #33 
