### PR TITLE
feat: env config block duration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "7038f81" }
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "5e1c811" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.0.9"
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "7038f81" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,7 +1,7 @@
 use graphql_client::{GraphQLQuery, Response};
 use serde_derive::{Deserialize, Serialize};
 use std::collections::HashMap;
-use tracing::debug;
+use tracing::trace;
 
 use poi_radio::SubgraphStatus;
 // Maybe later on move graphql to SDK as the queries are pretty standarded
@@ -160,6 +160,6 @@ pub async fn update_network_chainheads(
                 .collect::<Vec<String>>()
         })
         .ok_or(QueryError::IndexingError);
-    debug!("Updated networks: {:#?}", updated_networks);
+    trace!("Updated networks: {:#?}", updated_networks);
     Ok(subgraph_network_blocks)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,12 @@ use std::{
     sync::{Arc, Mutex as SyncMutex},
 };
 use tokio::sync::Mutex as AsyncMutex;
-use tracing::{debug, error};
+use tracing::{debug, error, info};
 
 use graphcast_sdk::{
     graphcast_agent::{
         message_typing::{get_indexer_stake, GraphcastMessage},
+        waku_handling::WakuHandlingError,
         GraphcastAgent,
     },
     graphql::{client_network::query_network_subgraph, client_registry::query_registry_indexer},
@@ -228,9 +229,9 @@ pub fn save_local_attestation(
 /// Custom callback for handling the validated GraphcastMessage, in this case we only save the messages to a local store
 /// to process them at a later time. This is required because for the processing we use async operations which are not allowed
 /// in the handler.
-pub fn attestation_handler() -> impl Fn(Result<GraphcastMessage<RadioPayloadMessage>, anyhow::Error>)
-{
-    |msg: Result<GraphcastMessage<RadioPayloadMessage>, anyhow::Error>| match msg {
+pub fn attestation_handler(
+) -> impl Fn(Result<GraphcastMessage<RadioPayloadMessage>, WakuHandlingError>) {
+    |msg: Result<GraphcastMessage<RadioPayloadMessage>, WakuHandlingError>| match msg {
         Ok(msg) => {
             debug!("Received message: {:?}", msg);
             MESSAGES.get().unwrap().lock().unwrap().push(msg);
@@ -267,38 +268,41 @@ pub async fn compare_attestations(
                             Some(remote_attestations) => {
                                 let mut remote_attestations = remote_attestations.clone();
 
-                        remote_attestations
-                        .sort_by(|a, b| a.stake_weight.partial_cmp(&b.stake_weight).unwrap());
+                            remote_attestations
+                                .sort_by(|a, b| a.stake_weight.partial_cmp(&b.stake_weight).unwrap());
 
-                    let most_attested_npoi = &remote_attestations.last().unwrap().npoi;
-                    if most_attested_npoi == &local_attestation.npoi {
-                        return Ok(format!(
-                            "POIs match for subgraph {ipfs_hash} on block {attestation_block}!"
-                        ));
-                    } else {
-                        return Err(anyhow!(format!(
-                            "POIs don't match for subgraph {ipfs_hash} on block {attestation_block}!"
-                        )
-                        .red()
-                        .bold()));
-                    }
+                            info!("Number of nPOI submitted for block {attestation_block}: {:#?}", remote_attestations.len());
+                            if remote_attestations.len() > 1 {
+                                debug!("Sorted attestations: {:#?}", remote_attestations);
+                            }
+
+                            let most_attested_npoi = &remote_attestations.last().unwrap().npoi;
+                            if most_attested_npoi == &local_attestation.npoi {
+                                return Ok(format!(
+                                    "POIs match for subgraph {ipfs_hash} on block {attestation_block}!: {most_attested_npoi}"
+                                ));
+                            } else {
+                                return Err(anyhow!(format!(
+                                    "POIs don't match for subgraph {ipfs_hash} on block {attestation_block}!"
+                                )
+                                ));
+                            }
                             },
                             None => {
                                 return Err(anyhow!(format!(
                                     "No record for subgraph {ipfs_hash} on block {attestation_block} found in remote attestations"
                                 )
-                                .yellow()
                                ));
                             }
                         }
                     }
                     None => {
-                        return Err(anyhow!(format!("No attestations for subgraph {ipfs_hash} on block {attestation_block} found in remote attestations store. Continuing...", ).yellow()))
+                        return Err(anyhow!(format!("No attestations for subgraph {ipfs_hash} on block {attestation_block} found in remote attestations store. Continuing...", )))
                     }
                 }
             }
             None => {
-                return Err(anyhow!(format!("No attestation for subgraph {ipfs_hash} on block {attestation_block} found in local attestations store. Continuing...", ).yellow()))
+                return Err(anyhow!(format!("No attestation for subgraph {ipfs_hash} on block {attestation_block} found in local attestations store. Continuing...", )))
             }
         }
     }
@@ -306,7 +310,7 @@ pub async fn compare_attestations(
     Err(anyhow!(format!(
         "The comparison did not execute successfully for on block {attestation_block}. Continuing...",
     )
-    .yellow()))
+    ))
 }
 
 #[cfg(test)]
@@ -654,7 +658,7 @@ mod tests {
         assert!(res.is_ok());
         assert_eq!(
             res.unwrap(),
-            "POIs match for subgraph my-awesome-hash on block 42!".to_string()
+            "POIs match for subgraph my-awesome-hash on block 42!: awesome-npoi".to_string()
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,9 @@ use graphcast_sdk::{
 use num_bigint::BigUint;
 use num_traits::Zero;
 use poi_radio::{
-    active_allocation_hashes, attestation_handler, compare_attestations, process_messages,
-    save_local_attestation, Attestation, BlockClock, LocalAttestationsMap, RadioPayloadMessage,
-    GRAPHCAST_AGENT, MESSAGES,
+    active_allocation_hashes, attestation_handler, compare_attestations, comparison_trigger,
+    process_messages, save_local_attestation, Attestation, BlockClock, LocalAttestationsMap,
+    RadioPayloadMessage, GRAPHCAST_AGENT, MESSAGES,
 };
 use std::collections::HashMap;
 use std::env;
@@ -48,12 +48,11 @@ async fn main() {
         env::var("NETWORK_SUBGRAPH").expect("No network subgraph endpoint provided.");
     let graphcast_network = env::var("GRAPHCAST_NETWORK").ok();
 
-    // Configure the amount of blocks spent collecting messages before attesting
-    //TODO: This should be more customized to network specific durations, or update comparison trigger by time
-    let collect_message_blocks: u64 = env::var("COLLECT_MESSAGE_BLOCKS")
-        .unwrap_or("10".to_string())
-        .parse::<u64>()
-        .unwrap_or(10);
+    // Configure the amount of time in seconds spent collecting messages before attesting
+    let collect_message_duration: i64 = env::var("COLLECT_MESSAGE_DURATION")
+        .unwrap_or("30".to_string())
+        .parse::<i64>()
+        .unwrap_or(30);
 
     // Option for where to host the waku node instance
     let waku_host = env::var("WAKU_HOST").ok();
@@ -194,8 +193,8 @@ async fn main() {
             let block_clock = block_store
                 .entry(network_name)
                 .or_insert_with(|| BlockClock {
-                    current_block: 0,
-                    compare_block: u64::MAX,
+                    current_block: latest_block.number,
+                    compare_block: message_block,
                 });
 
             // Wait a bit before querying information on the current block
@@ -203,6 +202,15 @@ async fn main() {
                 sleep(Duration::from_secs(5));
                 continue;
             }
+
+            let msgs = MESSAGES.get().unwrap().lock().unwrap().to_vec();
+            // first stored message block
+            let (compare_block, comparison_trigger) = comparison_trigger(
+                Arc::new(AsyncMutex::new(msgs)),
+                id.clone(),
+                collect_message_duration,
+            )
+            .await;
 
             debug!(
                 "{} {} {} {} {} {} {} {}",
@@ -213,20 +221,18 @@ async fn main() {
                 "🔗 Latest block: ".cyan(),
                 latest_block.number,
                 "🔗 Compare block: ".cyan(),
-                block_clock.compare_block
+                compare_block
             );
 
+            // Update block clock
             block_clock.current_block = latest_block.number;
 
-            if latest_block.number >= block_clock.compare_block {
-                debug!("{}", "Comparing attestations".magenta());
-
-                debug!("{}{:?}", "Messages: ".magenta(), MESSAGES);
+            if Utc::now().timestamp() >= comparison_trigger {
+                debug!("{}", "Comparing attestations");
+                trace!("{}{:?}", "Messages: ", MESSAGES);
 
                 let msgs = MESSAGES.get().unwrap().lock().unwrap().to_vec();
-
                 let remote_attestations = process_messages(
-                    //Arc<AsyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>
                     Arc::new(AsyncMutex::new(msgs)),
                     &registry_subgraph,
                     &network_subgraph,
@@ -234,9 +240,8 @@ async fn main() {
                 .await;
                 match remote_attestations {
                     Ok(remote_attestations) => {
-                        // let mut messages = ;
                         match compare_attestations(
-                            block_clock.compare_block - collect_message_blocks,
+                            compare_block,
                             remote_attestations,
                             Arc::clone(&local_attestations),
                         )
@@ -244,11 +249,20 @@ async fn main() {
                         {
                             Ok(msg) => {
                                 debug!("{}", msg.green().bold());
-                                MESSAGES.get().unwrap().lock().unwrap().clear();
+                                // Only clear the ones matching identifier and block number
+                                MESSAGES.get().unwrap().lock().unwrap().retain(|msg| {
+                                    msg.block_number != compare_block
+                                        || msg.identifier != id.clone()
+                                });
+                                debug!("Messages left: {:#?}", MESSAGES);
                             }
                             Err(err) => {
                                 error!("{}", err);
-                                MESSAGES.get().unwrap().lock().unwrap().clear();
+                                MESSAGES.get().unwrap().lock().unwrap().retain(|msg| {
+                                    msg.block_number != compare_block
+                                        || msg.identifier != id.clone()
+                                });
+                                debug!("Messages left: {:#?}", MESSAGES);
                             }
                         }
                     }
@@ -270,7 +284,6 @@ async fn main() {
                 latest_block.number
             );
             if latest_block.number >= message_block {
-                block_clock.compare_block = message_block + collect_message_blocks;
                 let block_hash = match GRAPHCAST_AGENT
                     .get()
                     .unwrap()


### PR DESCRIPTION
### Description

- Added logs during attestation process.
- Fixed a bug that is after compare_attestations returns, it cleared all the messages but should be only the ones attested (subgraph and block number specific)
- Allow wait duration configuration `COLLECT_MESSAGE_DURATION` between message_block and attestation block for all networks
- Update wait duration to be time based (seconds) instead of by blocks
- Calculate the comparison trigger - filter by identifier then get the smallest block_number and nonce, add the configured duration.

### Issue link (if applicable)
Resolves #40 
