### PR TITLE
chore: add tag to Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,4 +27,4 @@ jobs:
         with:
           context: ./
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.BASE_NAME }}
+          tags: ${{ env.REGISTRY }}/${{ env.BASE_NAME }}:${{ github.event.release.tag_name }}


### PR DESCRIPTION
This change will enable tagging our Docker image, it will automatically take the release tag and use that. This will greatly help upgradability.