### PR TITLE
refactor: logging improvement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
 # graphcast-sdk = { path = "../graphcast-rs"}
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "7e16481" }
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk", rev = "55076ee" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
@@ -27,7 +27,6 @@ regex = "1.7.1"
 ethers-contract = "2.0.0"
 ethers-core = "2.0.0"
 ethers-derive-eip712 = "2.0.0"
-colored = "2.0.0"
 partial_application = "0.2.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.15"


### PR DESCRIPTION
### Description

- In each main loop, info log on network chainhead, number of gossip peers, and number of tracked deployments (topics). At the end of main loop, info log on attestation results (number of checks, success, not found, and the details of divergence)
- indexer id stored and show when attesting
- added network name and deployment hash when printing block info
- Update naming of `message block` to `send message block`, and `compare block` to `compare time`

examples
```
  2023-03-15T18:49:03.854408Z  INFO graphcast_sdk::graphql::client_graph_node: Updated latest block pointers for 358 number of subgraphs
  
  2023-03-15T18:48:47.346233Z  INFO poi_radio: Deployment status:
IPFS Hash: QmRDGLp6BHwiH9HAE2NYEE3f7LrKuRqziHBv76trT4etgU
Network: mainnet
Send message block: 16835160
Latest block: 16835174
Reached send message block: true
Reached comparison time: true

  2023-03-15T18:48:49.442743Z  INFO poi_radio: nPOI matched for subgraph QmRDGLp6BHwiH9HAE2NYEE3f7LrKuRqziHBv76trT4etgU on block 16835160 with 1 of remote attestations

  2023-03-15T18:48:54.052389Z  INFO poi_radio: Operation summary:
Number of messages sent: 3
1 out of 5 deployments cross checked
Successful attestations: 1
Topics without attestations: 1
Divergence: []
```


### Issue link (if applicable)
Improves on #10 
Allow program panic as reasoned in #53 , potentially add more validations on operation set up
