### PR TITLE
feat: add basic prometheus + compare attestations fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /.fleet
 /examples/target
 boot_node_addr.conf
+data

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.0.14"
+graphcast-sdk = { package = "graphcast-sdk", git = "https://github.com/graphops/graphcast-sdk", branch = "petko/prometheus-toggle" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
@@ -36,6 +36,9 @@ secp256k1 = "0.25.0"
 hex = "0.4.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
+autometrics = {version = "0.2.4", features = ["prometheus-exporter"]}
+axum = "0.6.6"
+prometheus = "0.13.3"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,20 @@
+scrape_configs:
+  - job_name: example-api-metrics
+    metrics_path: /metrics
+    static_configs:
+    # Should make this port dynamic
+      - targets: ['localhost:3001']
+    # For a real deployment, you would want the scrape interval to be
+    # much longer but this is just for demo purposes and we want the
+    # data to show up quickly
+    scrape_interval: 200ms
+    honor_labels: false
+    honor_timestamps: true
+    scheme: http
+    follow_redirects: true
+    body_size_limit: 0
+    sample_limit: 0
+    label_limit: 0
+    label_name_length_limit: 0
+    label_value_length_limit: 0
+    target_limit: 0

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,85 @@
+use autometrics::{encode_global_metrics, global_metrics_exporter};
+use axum::http::StatusCode;
+use axum::routing::get;
+use axum::Router;
+use once_cell::sync::Lazy;
+use prometheus::{Counter, IntGaugeVec, Opts};
+use std::io::ErrorKind;
+use std::net::SocketAddr;
+use std::process::{Command, Stdio};
+use tracing::info;
+
+/// This handler serializes the metrics into a string for Prometheus to scrape
+async fn get_metrics() -> (StatusCode, String) {
+    match encode_global_metrics() {
+        Ok(metrics) => (StatusCode::OK, metrics),
+        Err(err) => (StatusCode::INTERNAL_SERVER_ERROR, format!("{err:?}")),
+    }
+}
+
+/// Run the API server as well as Prometheus and a traffic generator
+async fn handle_serve_metrics() {
+    // Set up the exporter to collect metrics
+    let _exporter = global_metrics_exporter();
+
+    let app = Router::new().route("/metrics", get(get_metrics));
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3001));
+    let server = axum::Server::bind(&addr);
+
+    server
+        .serve(app.into_make_service())
+        .await
+        .expect("Error starting example API server");
+}
+
+// Received (and validated) messages counter
+pub static VALIDATED_MESSAGES: Lazy<Counter> = Lazy::new(|| {
+    let counter = Counter::new(
+        "validated_messages_total",
+        "Total number of validated messages",
+    )
+    .expect("Failed to create validated_messages_total counter");
+    prometheus::register(Box::new(counter.clone()))
+        .expect("Failed to register validated_messages_total counter");
+    counter
+});
+
+// These are the subgraphs that are being actively cross-checked (the ones we are receiving remote attestations for)
+// Maybe CHECKED_SUBGRAPHS is a better name?
+pub static ACTIVE_SUBGRAPHS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    let opts = Opts::new(
+        "active_subgraphs",
+        "Number of subgraphs being actively crosschecked with other indexers",
+    );
+    let gauge_vec =
+        IntGaugeVec::new(opts, &["subgraph"]).expect("Failed to create active_subgraphs gauge");
+    prometheus::register(Box::new(gauge_vec.clone()))
+        .expect("Failed to register active_subgraphs gauge");
+    gauge_vec
+});
+
+pub fn start_prometheus_server() {
+    const PROMETHEUS_CONFIG_PATH: &str = "./prometheus.yml";
+
+    match Command::new("prometheus")
+        .args(["--config.file", PROMETHEUS_CONFIG_PATH])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Err(err) if err.kind() == ErrorKind::NotFound => {
+            panic!("Failed to start prometheus (do you have the prometheus binary installed and in your path?)");
+        }
+        Err(err) => {
+            panic!("Failed to start prometheus: {err}");
+        }
+        Ok(_) => {
+            info!(
+                "Running Prometheus on port 9090 (using config file: {PROMETHEUS_CONFIG_PATH})\n"
+            );
+        }
+    }
+
+    tokio::spawn(handle_serve_metrics());
+}


### PR DESCRIPTION
### Description
Adds basic Prometheus support and fixes issue in compare_attestations where only the first local attestation is crosschecked.

This is how the basic metrics look like:
![image](https://user-images.githubusercontent.com/32264020/226917368-c50960b7-1192-454d-9fdc-998a0832acb4.png)

They only track number of validated messages and subgraphs that are actively crosschecked (this is what helped discover the `compare_attestations` problem).

Recap of changes:
- Added a new `prometheus.yml` configuration file
- Imported and used metrics module in `src/lib.rs`
- Added metrics counters `VALIDATED_MESSAGES` and `ACTIVE_SUBGRAPHS` in `src/lib.rs`
- Updated `compare_attestations` function to set values for `ACTIVE_SUBGRAPHS` gauge
- Added `ipfs_hash` parameter to `compare_attestations` function
- Added new file `src/metrics/mod.rs` with metric handling functions and definitions
- Added conditional `start_prometheus_server` call in `src/main.rs` (will only be called if the `prometheus_metrics` toggle is on)
- Removed redundant regression test
 
### Issue link (if applicable)
Partially advances https://github.com/graphops/poi-radio/issues/61

**Next steps:**
- Attestation groups - https://github.com/graphops/poi-radio/issues/60
- Other metrics defined in this issue - https://github.com/graphops/poi-radio/issues/61
- Move core Prometheus setup in SDK and define an interface that Radios can use -  https://github.com/graphops/graphcast-sdk/issues/51

**Open questions:**
- Should we add toggles for customisable ports as part of this PR? Currently Prometheus starts up on port `9090` (might be a problem if it's already running?) and our Radio metrics endpoint is `3001`. Can also be done in a follow-up PR.