### PR TITLE
feat: pruning local+remote after expiry, update collect window to local

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = "0.0.14"
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"


### PR DESCRIPTION
### Description
Instead of using remote stored messages for determining the comparison trigger, use local attestations. 
- updated attestation struct to include timestamp
- For each identifier, find the smallest block and its timestamp for comparison trigger
- After comparing attestation for a certain deployment+block, prune corresponding remote messages and local attestations with equal or earlier block number.

### Issue link (if applicable)
Resolves #70
