### PR TITLE
refactor: deployment messages in parallel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ keywords=["graphprotocol", "data-integrity", "Indexer", "waku", "p2p"]
 categories=["network-programming", "web-programming::http-client"]
 
 [dependencies]
-graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
+graphcast-sdk = "0.0.17"
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
 serde = "1.0.147"
 serde_json = "1.0.87"
 sha3 = "0.10.6"
-tokio = { version = "1.1.1", features = ["full"] }
+tokio = { version = "1.1.1", features = ["full", "rt"] }
 anyhow = "1.0.69"
 graphql_client = "0.9.0"
 serde_derive = "1.0.114"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ pub async fn syncing_deployment_hashes(
         })
         .unwrap()
         .iter()
-        .filter(|&status| status.node != "removed")
+        .filter(|&status| status.node.is_some() && status.node != Some(String::from("removed")))
         .map(|s| s.subgraph.clone())
         .collect::<Vec<String>>()
 }


### PR DESCRIPTION
### Description

Use `tokio::spawn` for operating send and compare messages in different threads for deployments to improve operation efficiency.
Refactored the main loop for readability.

### Issue link (if applicable)
Resolves #66 

---
Wanted to add [benchmarking](https://github.com/bheisler/criterion.rs) to observe the effects for parallelizing tasks to send and compare messages by deployments, but seems to make more sense to test a single function at a time (by implementing them in a benchmark file) instead of measuring main function directly.