### PR TITLE
Expose API endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ anyhow = "1.0.69"
 graphql_client = "0.9.0"
 serde_derive = "1.0.114"
 reqwest = { version = "0.11.0", features = ["json"] }
-ethers = "2.0.0"
 thiserror = "1.0.40"
 regex = "1.7.1"
-ethers-contract = "2.0.0"
-ethers-core = "2.0.0"
-ethers-derive-eip712 = "2.0.2"
+ethers = "2.0.3"
+ethers-contract = "2.0.3"
+ethers-core = "2.0.3"
+ethers-derive-eip712 = "1.0.2"
 partial_application = "0.2.1"
 num-bigint = "0.4.3"
 num-traits = "0.2.15"
@@ -38,9 +38,20 @@ secp256k1 = "0.25.0"
 hex = "0.4.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-autometrics = {version = "0.3.2", features = ["prometheus-exporter"]}
-axum = "0.6.6"
+autometrics = {version = "0.3.2", features = ["prometheus-exporter", ]}
+axum = "0.5"
 prometheus = "0.13.3"
+# async-graphql = { version = "5.0", features = ["chrono", "dataloader"] }
+tower-http = { version = "0.4.0", features = ["trace", "cors"] }
+# async-graphql-axum = "5.0.7"
+# axum-macros = "0.3.7"
+async-graphql = "4.0.16"
+async-graphql-axum = "4.0.16"
+metrics = "0.20.1"
+metrics-exporter-prometheus = "0.11.0"
+opentelemetry = {version = "0.18.0", features = ["rt-tokio"]}
+opentelemetry-jaeger = {version = "0.17.0", features = ["rt-tokio"]}
+tracing-opentelemetry = "0.18.0"
 
 [dev-dependencies.cargo-husky]
 version = "1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,53 @@
+use axum::{extract::Extension, middleware, routing::get, Router, Server};
+use std::future::ready;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
+use tracing::info;
+
+use crate::attestation::LocalAttestationsMap;
+use crate::server::model::{build_schema, POIRadioContext};
+use crate::server::observability::{create_prometheus_recorder, track_metrics};
+use crate::server::routes::{graphql_handler, graphql_playground, health};
+use crate::shutdown_signal;
+
+pub mod model;
+pub mod observability;
+pub mod routes;
+
+pub async fn run_server(
+    host: String,
+    port: u16,
+    running_program: Arc<AtomicBool>,
+    local_attestations: Arc<AsyncMutex<LocalAttestationsMap>>,
+) {
+    info!("Initializing HTTP server");
+    let context = Arc::new(POIRadioContext::init(Arc::clone(&local_attestations)).await);
+
+    let schema = build_schema(Arc::clone(&context)).await;
+
+    let prometheus_recorder = create_prometheus_recorder();
+
+    info!("API Service starting at {host}:{port}");
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route("/metrics", get(move || ready(prometheus_recorder.render())))
+        .route(
+            "/api/v1/graphql",
+            get(graphql_playground).post(graphql_handler),
+        )
+        .route_layer(middleware::from_fn(track_metrics))
+        .layer(Extension(schema))
+        .layer(Extension(context));
+    let addr =
+        SocketAddr::from_str(&format!("{}:{}", host, port)).expect("Start Prometheus metrics");
+
+    Server::bind(&addr)
+        .serve(app.into_make_service())
+        .with_graceful_shutdown(shutdown_signal(running_program))
+        .await
+        .unwrap();
+}

--- a/src/server/model/mod.rs
+++ b/src/server/model/mod.rs
@@ -1,0 +1,101 @@
+use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema};
+use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
+
+use crate::attestation::{attestations_to_vec, AttestationEntry, LocalAttestationsMap};
+use crate::{RadioPayloadMessage, MESSAGES};
+
+pub(crate) type POIRadioSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
+
+// Unified query object
+// Later add attestations and Graphcast Agent (or topics)
+#[derive(Default)]
+pub struct QueryRoot;
+
+#[Object]
+impl QueryRoot {
+    async fn radio_payload_messages(
+        &self,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<GraphcastMessage<RadioPayloadMessage>>, anyhow::Error> {
+        Ok(MESSAGES.get().unwrap().lock().unwrap().to_vec())
+    }
+
+    async fn radio_payload_messages_by_deployment(
+        &self,
+        _ctx: &Context<'_>,
+        identifier: String,
+    ) -> Result<Vec<GraphcastMessage<RadioPayloadMessage>>, anyhow::Error> {
+        Ok(MESSAGES
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .filter(|message| message.identifier == identifier.clone())
+            .collect::<Vec<_>>())
+    }
+
+    async fn local_attestations(
+        &self,
+        ctx: &Context<'_>,
+    ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
+        let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
+        let local = attestations_to_vec(attestations).await;
+
+        Ok(local)
+    }
+
+    async fn local_attestations_by_deployment(
+        &self,
+        ctx: &Context<'_>,
+        identifier: String,
+    ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
+        let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
+        let filtered = attestations_to_vec(attestations)
+            .await
+            .into_iter()
+            .filter(|entry| entry.deployment == identifier.clone())
+            .collect::<Vec<_>>();
+
+        Ok(filtered)
+    }
+
+    async fn local_attestations_by_deployment_block(
+        &self,
+        ctx: &Context<'_>,
+        identifier: String,
+        block: u64,
+    ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
+        let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
+        let filtered = attestations_to_vec(attestations)
+            .await
+            .into_iter()
+            .filter(|entry| entry.deployment == identifier.clone() && entry.block_number == block)
+            .collect::<Vec<_>>();
+
+        Ok(filtered)
+    }
+}
+
+pub async fn build_schema(ctx: Arc<POIRadioContext>) -> POIRadioSchema {
+    Schema::build(QueryRoot, EmptyMutation, EmptySubscription)
+        .data(Arc::clone(&ctx.local_attestations))
+        .finish()
+}
+
+pub struct POIRadioContext {
+    pub local_attestations: Arc<AsyncMutex<LocalAttestationsMap>>,
+}
+
+impl POIRadioContext {
+    pub async fn init(local_attestations: Arc<AsyncMutex<LocalAttestationsMap>>) -> Self {
+        Self { local_attestations }
+    }
+
+    pub async fn local_attestations(&self) -> LocalAttestationsMap {
+        self.local_attestations.lock().await.clone()
+    }
+}

--- a/src/server/observability/mod.rs
+++ b/src/server/observability/mod.rs
@@ -1,0 +1,51 @@
+use axum::{extract::MatchedPath, http::Request, middleware::Next, response::IntoResponse};
+use metrics_exporter_prometheus::{Matcher, PrometheusBuilder, PrometheusHandle};
+use std::time::Instant;
+
+const REQUEST_DURATION_METRIC_NAME: &str = "http_requests_duration_seconds";
+
+pub(crate) fn create_prometheus_recorder() -> PrometheusHandle {
+    const EXPONENTIAL_SECONDS: &[f64] = &[
+        0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+    ];
+
+    PrometheusBuilder::new()
+        .set_buckets_for_metric(
+            Matcher::Full(REQUEST_DURATION_METRIC_NAME.to_string()),
+            EXPONENTIAL_SECONDS,
+        )
+        .unwrap_or_else(|_| {
+            panic!(
+                "Could not initialize the bucket for '{}'",
+                REQUEST_DURATION_METRIC_NAME
+            )
+        })
+        .install_recorder()
+        .expect("Could not install the Prometheus recorder")
+}
+
+pub(crate) async fn track_metrics<B>(req: Request<B>, next: Next<B>) -> impl IntoResponse {
+    let start = Instant::now();
+    let path = if let Some(matched_path) = req.extensions().get::<MatchedPath>() {
+        matched_path.as_str().to_owned()
+    } else {
+        req.uri().path().to_owned()
+    };
+    let method = req.method().clone();
+
+    let response = next.run(req).await;
+
+    let latency = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+
+    let labels = [
+        ("method", method.to_string()),
+        ("path", path),
+        ("status", status),
+    ];
+
+    metrics::increment_counter!("http_requests_total", &labels);
+    metrics::histogram!(REQUEST_DURATION_METRIC_NAME, latency, &labels);
+
+    response
+}

--- a/src/server/routes/mod.rs
+++ b/src/server/routes/mod.rs
@@ -1,0 +1,61 @@
+use async_graphql::http::{playground_source, GraphQLPlaygroundConfig};
+use async_graphql_axum::{GraphQLRequest, GraphQLResponse};
+use axum::{
+    extract::Extension,
+    http::StatusCode,
+    response::{Html, IntoResponse},
+    Json,
+};
+use opentelemetry::trace::TraceContextExt;
+use serde::Serialize;
+use std::sync::Arc;
+use tracing::{span, trace, Instrument, Level};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+use super::model::POIRadioContext;
+use crate::server::model::POIRadioSchema;
+
+#[derive(Serialize)]
+struct Health {
+    healthy: bool,
+}
+
+pub(crate) async fn health() -> impl IntoResponse {
+    let health = Health { healthy: true };
+
+    (StatusCode::OK, Json(health))
+}
+
+pub(crate) async fn graphql_playground() -> impl IntoResponse {
+    Html(playground_source(
+        GraphQLPlaygroundConfig::new("/").subscription_endpoint("/ws"),
+    ))
+}
+
+pub(crate) async fn graphql_handler(
+    req: GraphQLRequest,
+    Extension(schema): Extension<POIRadioSchema>,
+    Extension(context): Extension<Arc<POIRadioContext>>,
+) -> GraphQLResponse {
+    let span = span!(Level::TRACE, "graphql_execution");
+
+    trace!("Processing GraphQL request");
+
+    let local = context.local_attestations().await;
+
+    let response = async move { schema.execute(req.into_inner().data(local)).await }
+        .instrument(span.clone())
+        .await;
+
+    trace!("Processing GraphQL request finished");
+
+    response
+        .extension(
+            "traceId",
+            async_graphql::Value::String(format!(
+                "{}",
+                span.context().span().span_context().trace_id()
+            )),
+        )
+        .into()
+}


### PR DESCRIPTION
### Description

Default to spin up server at `localhost:7700` (refactor in the SDK to provide server-host, server-port)

Available routes
- `/health` for health status
- `/metrics` for http service metrics about the server
- `/api/v1/graphql` for GET and POST requests with playground interface

Example
<img width="1194" alt="Screenshot 2023-04-13 at 3 49 29 PM" src="https://user-images.githubusercontent.com/60078528/231783850-4385ab49-8e12-4f7f-8fd7-343ef331d44d.png">

Basic queries
```
schema {
  query: QueryRoot
}

# A wrapper around an attested NPOI, tracks Indexers that have sent it plus their accumulated stake
type Attestation {
  npoi: String!
  stakeWeight: Int!
  senders: [String!]!
  senderGroupHash: String!
  timestamp: [Int!]!
}

type AttestationEntry {
  deployment: String!
  blockNumber: Int!
  attestation: Attestation!
}

# GraphcastMessage type casts over radio payload
type GraphcastMessage {
  # Graph identifier for the entity the radio is communicating about
  identifier: String!

  # content to share about the identified entity
  payload: RadioPayloadMessage

  # nonce cached to check against the next incoming message
  nonce: Int!

  # blockchain relevant to the message
  network: String!

  # block relevant to the message
  blockNumber: Int!

  # block hash generated from the block number
  blockHash: String!

  # signature over radio payload
  signature: String!
}

type QueryRoot {
  radioPayloadMessages: [GraphcastMessage!]!
  radioPayloadMessagesByDeployment(identifier: String!): [GraphcastMessage!]!
  localAttestations: [AttestationEntry!]!
  localAttestationsByDeployment(identifier: String!): [AttestationEntry!]!
  localAttestationsByDeploymentBlock(
    identifier: String!
    block: Int!
  ): [AttestationEntry!]!
}

type RadioPayloadMessage {
  identifier: String!
  content: String!
}


```


### Issue link (if applicable)
Resolves #86 

### Next step
- Utilize graphQL resolver `where` filter instead of creating new query functions
- Create more complex and useful resolvers

### Checklist
- [x] Have you tested your changes? 
- [ ] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the neccessary changes? 
  - Not yet
