### PR TITLE
Comparison results by graphql query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs
 boot_node_addr.conf
 data
 *.swp
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,3 +64,7 @@ version = "1"
 default-features = false
 # Disable features which are enabled by default
 features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"]
+
+[profile.dev]
+debug = true
+debuginfo = 2

--- a/e2e-tests.docker-compose.yml
+++ b/e2e-tests.docker-compose.yml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       dockerfile: e2e-tests.Dockerfile
-    command: [ "--instance=basic" ]
     environment:
       PRIVATE_KEY: ${PRIVATE_KEY}
       GRAPH_NODE_STATUS_ENDPOINT: ${GRAPH_NODE_STATUS_ENDPOINT}
@@ -12,11 +11,11 @@ services:
       NETWORK_SUBGRAPH: ${NETWORK_SUBGRAPH}
       GRAPHCAST_NETWORK: ${GRAPHCAST_NETWORK}
       RUST_LOG: ${RUST_LOG}
+      INSTANCE: "basic"
   divergent-instance:
     build:
       context: .
       dockerfile: e2e-tests.Dockerfile
-    command: [ "--instance=divergent" ]
     environment:
       PRIVATE_KEY: ${PRIVATE_KEY}
       GRAPH_NODE_STATUS_ENDPOINT: ${GRAPH_NODE_STATUS_ENDPOINT}
@@ -24,11 +23,11 @@ services:
       NETWORK_SUBGRAPH: ${NETWORK_SUBGRAPH}
       GRAPHCAST_NETWORK: ${GRAPHCAST_NETWORK}
       RUST_LOG: ${RUST_LOG}
+      INSTANCE: "divergent"
   invalid-payload-instance:
     build:
       context: .
       dockerfile: e2e-tests.Dockerfile
-    command: [ "--instance=invalid_payload" ]
     environment:
       PRIVATE_KEY: ${PRIVATE_KEY}
       GRAPH_NODE_STATUS_ENDPOINT: ${GRAPH_NODE_STATUS_ENDPOINT}
@@ -36,11 +35,11 @@ services:
       NETWORK_SUBGRAPH: ${NETWORK_SUBGRAPH}
       GRAPHCAST_NETWORK: ${GRAPHCAST_NETWORK}
       RUST_LOG: ${RUST_LOG}
+      INSTANCE: "invalid_payload"
   invalid-nonce-instance:
     build:
       context: .
       dockerfile: e2e-tests.Dockerfile
-    command: [ "--instance=invalid_nonce" ]
     environment:
       PRIVATE_KEY: ${PRIVATE_KEY}
       GRAPH_NODE_STATUS_ENDPOINT: ${GRAPH_NODE_STATUS_ENDPOINT}
@@ -48,11 +47,11 @@ services:
       NETWORK_SUBGRAPH: ${NETWORK_SUBGRAPH}
       GRAPHCAST_NETWORK: ${GRAPHCAST_NETWORK}
       RUST_LOG: ${RUST_LOG}
+      INSTANCE: "invalid_nonce"
   invalid-block-hash-instance:
     build:
       context: .
       dockerfile: e2e-tests.Dockerfile
-    command: [ "--instance=invalid_hash" ]
     environment:
       PRIVATE_KEY: ${PRIVATE_KEY}
       GRAPH_NODE_STATUS_ENDPOINT: ${GRAPH_NODE_STATUS_ENDPOINT}
@@ -60,3 +59,4 @@ services:
       NETWORK_SUBGRAPH: ${NETWORK_SUBGRAPH}
       GRAPHCAST_NETWORK: ${GRAPHCAST_NETWORK}
       RUST_LOG: ${RUST_LOG}
+      INSTANCE: "invalid_hash"

--- a/integration-tests/src/utils.rs
+++ b/integration-tests/src/utils.rs
@@ -63,13 +63,15 @@ pub fn round_to_nearest(number: i64) -> i64 {
     (number / 10) * 10 + if number % 10 > 4 { 10 } else { 0 }
 }
 
-pub fn generate_random_address() -> String {
+pub fn generate_random_private_key() -> SecretKey {
     let mut rng = thread_rng();
     let mut private_key = [0u8; 32];
     rng.fill(&mut private_key[..]);
 
-    let private_key = SecretKey::from_slice(&private_key).expect("Error parsing secret key");
+    SecretKey::from_slice(&private_key).expect("Error parsing secret key")
+}
 
+pub fn private_key_to_address(private_key: SecretKey) -> String {
     let public_key =
         secp256k1::PublicKey::from_secret_key(&secp256k1::Secp256k1::new(), &private_key)
             .serialize_uncompressed();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
-use async_graphql::SimpleObject;
-use attestation::AttestationError;
+use async_graphql::{Error, ErrorExtensions, SimpleObject};
 use autometrics::autometrics;
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
@@ -18,7 +17,8 @@ use tokio::signal;
 use tracing::{error, trace};
 
 use graphcast_sdk::{
-    config::CoverageLevel, graphcast_agent::GraphcastAgentError,
+    config::{Config, CoverageLevel},
+    graphcast_agent::GraphcastAgentError,
     graphql::client_graph_node::get_indexing_statuses,
 };
 use graphcast_sdk::{
@@ -30,6 +30,7 @@ use graphcast_sdk::{
     BlockPointer,
 };
 
+use crate::attestation::AttestationError;
 use crate::metrics::{CACHED_MESSAGES, VALIDATED_MESSAGES};
 
 pub mod attestation;
@@ -49,6 +50,9 @@ pub static GRAPHCAST_AGENT: OnceCell<GraphcastAgent> = OnceCell::new();
 /// it is not allowed in the handler itself.
 pub static MESSAGES: OnceCell<Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>> =
     OnceCell::new();
+
+/// Radio's global config
+pub static CONFIG: OnceCell<Arc<SyncMutex<Config>>> = OnceCell::new();
 
 #[derive(Eip712, EthAbiType, Clone, Message, Serialize, Deserialize, PartialEq, SimpleObject)]
 #[eip712(
@@ -254,6 +258,12 @@ impl OperationError {
             }
             e => OperationError::Others(e.to_string()),
         }
+    }
+}
+
+impl ErrorExtensions for OperationError {
+    fn extend(&self) -> Error {
+        Error::new(format!("{}", self))
     }
 }
 

--- a/src/server/model/mod.rs
+++ b/src/server/model/mod.rs
@@ -2,9 +2,13 @@ use async_graphql::{Context, EmptyMutation, EmptySubscription, Object, Schema};
 use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
 use std::sync::Arc;
 use tokio::sync::Mutex as AsyncMutex;
+use tracing::debug;
 
-use crate::attestation::{attestations_to_vec, AttestationEntry, LocalAttestationsMap};
-use crate::{RadioPayloadMessage, MESSAGES};
+use crate::attestation::{
+    attestations_to_vec, compare_attestations, process_messages, AttestationEntry,
+    AttestationError, ComparisonResult, LocalAttestationsMap,
+};
+use crate::{RadioPayloadMessage, CONFIG, MESSAGES};
 
 pub(crate) type POIRadioSchema = Schema<QueryRoot, EmptyMutation, EmptySubscription>;
 
@@ -40,42 +44,105 @@ impl QueryRoot {
     async fn local_attestations(
         &self,
         ctx: &Context<'_>,
-    ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
-        let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
-        let local = attestations_to_vec(attestations).await;
-
-        Ok(local)
-    }
-
-    async fn local_attestations_by_deployment(
-        &self,
-        ctx: &Context<'_>,
-        identifier: String,
+        identifier: Option<String>,
+        block: Option<u64>,
     ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
         let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
         let filtered = attestations_to_vec(attestations)
             .await
             .into_iter()
-            .filter(|entry| entry.deployment == identifier.clone())
+            .filter(|entry| filter_fn(entry, &identifier, &block))
             .collect::<Vec<_>>();
 
         Ok(filtered)
     }
 
-    async fn local_attestations_by_deployment_block(
+    // TODO: Reproduce tabular summary view. use process_message and compare_attestations
+    async fn comparison_results(
         &self,
         ctx: &Context<'_>,
-        identifier: String,
+        deployment: Option<String>,
+        block: Option<u64>,
+    ) -> Result<Vec<ComparisonResult>, anyhow::Error> {
+        // Utilize the provided filters on local_attestations
+        let locals = match self.local_attestations(ctx, deployment, block).await {
+            Ok(r) => r,
+            Err(e) => return Err(e),
+        };
+
+        let mut res = vec![];
+        for entry in locals {
+            let r = self
+                .comparison_result(ctx, entry.deployment, entry.block_number)
+                .await;
+            // Return err if just one has err? (ignored for now)
+            if r.is_ok() {
+                res.push(r.unwrap());
+            }
+        }
+
+        Ok(res)
+    }
+
+    async fn comparison_result(
+        &self,
+        ctx: &Context<'_>,
+        deployment: String,
         block: u64,
-    ) -> Result<Vec<AttestationEntry>, anyhow::Error> {
-        let attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
-        let filtered = attestations_to_vec(attestations)
-            .await
-            .into_iter()
-            .filter(|entry| entry.deployment == identifier.clone() && entry.block_number == block)
-            .collect::<Vec<_>>();
+    ) -> Result<ComparisonResult, AttestationError> {
+        let local_attestations = &ctx.data_unchecked::<Arc<AsyncMutex<LocalAttestationsMap>>>();
+        let filter_msg: Vec<GraphcastMessage<RadioPayloadMessage>> = MESSAGES
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|&m| m.block_number == block)
+            .cloned()
+            .collect();
 
-        Ok(filtered)
+        let registry_subgraph = CONFIG
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .registry_subgraph
+            .clone();
+        let network_subgraph = CONFIG
+            .get()
+            .unwrap()
+            .lock()
+            .unwrap()
+            .network_subgraph
+            .clone();
+        let remote_attestations_result =
+            process_messages(filter_msg, &registry_subgraph, &network_subgraph).await;
+        let remote_attestations = match remote_attestations_result {
+            Ok(remote) => {
+                debug!(
+                    "Processed message\n{}: {}",
+                    "Number of unique remote POIs",
+                    remote.len(),
+                );
+                remote
+            }
+            Err(err) => {
+                debug!(
+                    "{}",
+                    format!("{}{}", "An error occured while parsing messages: {}", err)
+                );
+                return Err(err);
+            }
+        };
+        let comparison_result = compare_attestations(
+            block,
+            remote_attestations,
+            Arc::clone(local_attestations),
+            &deployment.clone(),
+        )
+        .await;
+
+        Ok(comparison_result)
     }
 }
 
@@ -97,4 +164,17 @@ impl POIRadioContext {
     pub async fn local_attestations(&self) -> LocalAttestationsMap {
         self.local_attestations.lock().await.clone()
     }
+}
+
+/// Filter funciton for Attestations on deployment and block
+fn filter_fn(entry: &AttestationEntry, identifier: &Option<String>, block: &Option<u64>) -> bool {
+    let is_matching_deployment = match identifier {
+        Some(dep) => entry.deployment == dep.clone(),
+        None => true, // Skip check
+    };
+    let is_matching_block = match block {
+        Some(b) => entry.block_number == *b,
+        None => true, // Skip check
+    };
+    is_matching_deployment && is_matching_block
 }


### PR DESCRIPTION
### Description
- Restructured `ComparisonResult` and refactored the original Enum as `ComparisonResultType` 
- Allow direct query to comparison results, with options to specify the interested deployment and/or block number
- Created a global instance for Radio config
- Refactored `localAttestations` query to optionally take in `deployment` and `block`

Example query
```
{
  radioPayloadMessages{
    identifier
    nonce
    blockNumber
    network
    signature
  }
  // Optionally provide fields for filter
  localAttestations(deployment: "", block: 0){
    deployment
    blockNumber
    attestation{
      npoi
    }
  }
  // Optionally provide fields for filter
  comparisonResults(deployment: "", block: 0){
    deployment
    blockNumber
    resultType
    localAttestation{
      npoi
    }
    attestations{
      npoi
    }
  }
}

```
### Issue link (if applicable)
Resolves #93

### Checklist
- [x] Have you tested your changes? 
- [ ] Does this PR include changes that require our documentation to be udpated, if so, have you created a PR on the docs repo to make the neccessary changes?
