### PR TITLE
fix: return empty vec if indexer_allocations function fails

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,12 @@
 ### Description
-*Add a brief overview of the changes and motivation behind them here*
+
+_Add a brief overview of the changes and motivation behind them here_
 
 ### Issue link (if applicable)
+
 [Link to issue]()
 
 ### Checklist
-- [ ] Have you tested your changes? 
-- [ ] Does this PR include changes that require our documentation to be udpated, if so, have you created a PR on the docs repo to make the neccessary changes?
+
+- [ ] Have you tested your changes?
+- [ ] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the necessary changes?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,12 +113,11 @@ pub async fn active_allocation_hashes(
 ) -> Vec<String> {
     query_network_subgraph(network_subgraph.to_string(), indexer_address)
         .await
-        .map_err(|e| -> Vec<String> {
+        .map(|result| result.indexer_allocations())
+        .unwrap_or_else(|e| {
             error!("Topic generation error: {}", e);
-            [].to_vec()
+            vec![]
         })
-        .unwrap()
-        .indexer_allocations()
 }
 
 /// Generate content topics for all deployments that are syncing on Graph node


### PR DESCRIPTION
### Description
Modified `active_allocation_hashes` to return an empty vec if the query response (`result.indexer_allocations()`) has errors.  No need for a retry mechanism because `generate_topics` is already being called periodically in `main.rs` (L143):
```rust
if Utc::now().timestamp() % 120 == 0 {
    GRAPHCAST_AGENT
        .get()
        .unwrap()
        .update_content_topics(generate_topics().await)
        .await;
}
```
### Issue link (if applicable)
https://github.com/graphops/poi-radio/issues/109

### Checklist
- [x] Have you tested your changes? 
- [x] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the necessary changes? - No changes
