### PR TITLE
refactor: move config parsing to Radio

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,59 +104,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anstream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e579a7752471abc2a8268df8b20005e3eadd975f585398f17efcfd8d4927371"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcd8291a340dd8ac70e18878bc4501dd7b4ff970cfa21c207d36ece51ea88fd"
-dependencies = [
- "anstyle",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "anyhow"
-version = "1.0.70"
+version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
 name = "arrayref"
@@ -369,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "auto_impl"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a8c1df849285fbacd587de7818cc7d13be6cd2cbcd47a04fb1801b0e2706e33"
+checksum = "fee3da8ef1276b0bee5dd1c7258010d8fffd31801447323115a25560e1327b89"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
@@ -450,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.16"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113713495a32dd0ab52baf5c10044725aa3aec00b31beda84218e469029b72a3"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core 0.3.4",
@@ -523,7 +474,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.6.2",
  "object",
  "rustc-demangle",
 ]
@@ -673,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.0"
+version = "3.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
+checksum = "9b1ce199063694f33ffb7dd4e0ee620741495c32833cde5aa08f02a0bf96f0c8"
 
 [[package]]
 name = "byte-slice-cast"
@@ -829,14 +780,14 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.23"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
+ "clap_derive",
+ "clap_lex",
  "indexmap",
  "once_cell",
  "strsim",
@@ -845,52 +796,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "clap"
-version = "4.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956ac1f6381d8d82ab4684768f89c0ea3afe66925ceadb4eeb3fc452ffc55d62"
-dependencies = [
- "clap_builder",
- "clap_derive 4.2.0",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84080e799e54cff944f4b4a4b0e71630b0e0443b25b985175c7dddc1a859b749"
-dependencies = [
- "anstream",
- "anstyle",
- "bitflags",
- "clap_lex 0.4.1",
- "strsim",
-]
-
-[[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ae6371b8bdc8b7d3959e9cf7b22d4435ef3e79e138688421ec654acf8c81b008"
 dependencies = [
  "heck 0.4.1",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.15",
 ]
 
 [[package]]
@@ -901,12 +816,6 @@ checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
-
-[[package]]
-name = "clap_lex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
 
 [[package]]
 name = "codespan-reporting"
@@ -973,12 +882,6 @@ dependencies = [
  "sha3",
  "thiserror",
 ]
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -1176,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-bigint"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2538c4e68e52548bacb3e83ac549f903d44f011ac9d5abb5e132e67d0808f7"
+checksum = "cf4c2f4e1afd912bc40bfd6fed5d9dc1f288e0ba01bfcc835cc5bc3eb13efe15"
 dependencies = [
  "generic-array",
  "rand_core 0.6.4",
@@ -1390,9 +1293,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b14af2045fa69ed2b7a48934bebb842d0f33e73e96e78766ecb14bb5347a11"
+checksum = "05e58dffcdcc8ee7b22f0c1f71a69243d7c2d9ad87b5a14361f2424a1565c219"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -1505,7 +1408,7 @@ version = "0.16.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48e5d537b8a30c0b023116d981b16334be1485af7ca68db3a2b7024cbc957fd"
 dependencies = [
- "der 0.7.4",
+ "der 0.7.5",
  "digest 0.10.6",
  "elliptic-curve 0.13.4",
  "rfc6979 0.4.0",
@@ -1545,7 +1448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c71eaa367f2e5d556414a8eea812bc62985c879748d6403edabd9cb03f16e7"
 dependencies = [
  "base16ct 0.2.0",
- "crypto-bigint 0.5.1",
+ "crypto-bigint 0.5.2",
  "digest 0.10.6",
  "ff 0.13.0",
  "generic-array",
@@ -1603,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "enr"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb4d5fbf6f56acecd38f5988eb2e4ae412008a2a30268c748c701ec6322f39d4"
+checksum = "cf56acd72bb22d2824e66ae8e9e5ada4d0de17a69c7fd35569dde2ada8ec9116"
 dependencies = [
  "base64 0.13.1",
  "bytes",
@@ -1712,13 +1615,13 @@ dependencies = [
 
 [[package]]
 name = "ethers"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "356eaf2e3947efa975c3f953e33f73193e5e21b9d8bab26c3ca532676931696f"
+checksum = "8d5486fdc149826f38c388f26a7df72534ee3f20d3a3f72539376fa7b3bbc43d"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-etherscan",
  "ethers-middleware",
  "ethers-providers",
@@ -1728,11 +1631,11 @@ dependencies = [
 
 [[package]]
 name = "ethers-addressbook"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56f1c92cb7c406794c8324158da4caf9e54018e28b776df8155085e1d06db75"
+checksum = "1c66a426b824a0f6d1361ad74b6b01adfd26c44ee1e14c3662dcf28406763ec5"
 dependencies = [
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "once_cell",
  "serde",
  "serde_json",
@@ -1740,13 +1643,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a328cb42014ac0ac577a8dac32eb658ee0f32b5a9a5317a0329ac1d4201f1c6"
+checksum = "dfa43e2e69632492d7b38e59465d125a0066cf4c477390ece00d3acbd11b338b"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-providers",
  "futures-util",
  "hex",
@@ -1759,13 +1662,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-abigen"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96813e4b58b6c6b817367380db900dddbd67bfe27610ec89fd3263778d5a4aa"
+checksum = "2edb8fdbf77459819a443234b461171a024476bfc12f1853b889a62c6e1185ff"
 dependencies = [
  "Inflector",
  "dunce",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-etherscan",
  "eyre",
  "getrandom 0.2.9",
@@ -1786,13 +1689,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-contract-derive"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373068bb24b4dea8fe0d1758aadab2dd4ec9de1d2c28316439cadcda3ed48eae"
+checksum = "939b0c37746929f869285ee37d270b7c998d80cc7404c2e20dda8efe93e3b295"
 dependencies = [
  "Inflector",
  "ethers-contract-abigen",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "hex",
  "proc-macro2",
  "quote",
@@ -1833,9 +1736,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5f8f85ba96698eab9a4782ed2215d0979b1981b99f1be0726c200ffdac22f5"
+checksum = "198ea9efa8480fa69f73d31d41b1601dace13d053c6fe4be6f5878d9dfcf0108"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -1877,11 +1780,11 @@ dependencies = [
 
 [[package]]
 name = "ethers-etherscan"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cfc3d36be9e16bac241e1d59ec9ace00e8e4241c09f604a0f65158eb37d4878"
+checksum = "196a21d6939ab78b7a1e4c45c2b33b0c2dd821a2e1af7c896f06721e1ba2a0c7"
 dependencies = [
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-solc",
  "getrandom 0.2.9",
  "reqwest",
@@ -1894,14 +1797,14 @@ dependencies = [
 
 [[package]]
 name = "ethers-middleware"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6f3543b4f6679b2558901c4b323cecb06b19239439d2588fa8b489bac9675d"
+checksum = "75594cc450992fc7de701c9145de612325fd8a18be765b8ae78767ba2b74876f"
 dependencies = [
  "async-trait",
  "auto_impl",
  "ethers-contract",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-etherscan",
  "ethers-providers",
  "ethers-signers",
@@ -1921,16 +1824,16 @@ dependencies = [
 
 [[package]]
 name = "ethers-providers"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9d2cbed43cf618004dbe339e389e10dae46ea8e55872ab63a25fad25a6082a"
+checksum = "1009041f40476b972b5d79346cc512e97c662b1a0a2f78285eabe9a122909783"
 dependencies = [
  "async-trait",
  "auto_impl",
  "base64 0.21.0",
  "bytes",
- "enr 0.8.0",
- "ethers-core 2.0.3",
+ "enr 0.8.1",
+ "ethers-core 2.0.4",
  "futures-core",
  "futures-timer",
  "futures-util",
@@ -1958,16 +1861,16 @@ dependencies = [
 
 [[package]]
 name = "ethers-signers"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56871f70b97cc5cced5c39c88a0196c206d8f7fb8e1e0952fbf1fb73c033219"
+checksum = "c3bd11ad6929f01f01be74bb00d02bbd6552f22de030865c898b340a3a592db1"
 dependencies = [
  "async-trait",
  "coins-bip32",
  "coins-bip39",
  "elliptic-curve 0.13.4",
  "eth-keystore",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "hex",
  "rand 0.8.5",
  "sha2 0.10.6",
@@ -1977,13 +1880,13 @@ dependencies = [
 
 [[package]]
 name = "ethers-solc"
-version = "2.0.3"
+version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e967e60bca8fc83d640a7aebd1492d625c43e86b88a5a5bb08b1019472d5d6b"
+checksum = "2284784306de73d8ad1bc792ecc1b87da0268185683698d60fd096d23d168c99"
 dependencies = [
  "cfg-if",
  "dunce",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "getrandom 0.2.9",
  "glob",
  "hex",
@@ -2103,12 +2006,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.7.1",
 ]
 
 [[package]]
@@ -2363,19 +2266,18 @@ dependencies = [
 [[package]]
 name = "graphcast-sdk"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff7d859d94c7be8975deb5bf57fe8ed696a5d6042688cbdd60b6ac8dadb1a04"
+source = "git+https://github.com/graphops/graphcast-sdk#0be6b5d798a211925447f6455c90f4be0efcb866"
 dependencies = [
  "anyhow",
  "async-graphql",
  "async-graphql-axum",
  "chrono",
- "clap 3.2.23",
+ "clap",
  "data-encoding",
  "dotenv",
  "ethers",
  "ethers-contract",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-derive-eip712",
  "graphql_client 0.12.0",
  "lazy_static",
@@ -2660,11 +2562,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2774,7 +2676,7 @@ dependencies = [
  "http",
  "hyper",
  "log",
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "rustls-native-certs",
  "tokio",
  "tokio-rustls 0.24.0",
@@ -3030,9 +2932,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.19.9"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f34313ec00c2eb5c3c87ca6732ea02dcf3af99c3ff7a8fb622ffb99c9d860a87"
+checksum = "0a1cbf952127589f2851ab2046af368fd20645491bb4b376f04b7f94d7a9837b"
 dependencies = [
  "ascii-canvas",
  "bit-set",
@@ -3042,7 +2944,6 @@ dependencies = [
  "itertools",
  "lalrpop-util",
  "petgraph",
- "pico-args",
  "regex",
  "regex-syntax 0.6.29",
  "string_cache",
@@ -3053,9 +2954,9 @@ dependencies = [
 
 [[package]]
 name = "lalrpop-util"
-version = "0.19.9"
+version = "0.19.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5c1f7869c94d214466c5fd432dfed12c379fd87786768d36455892d46b18edd"
+checksum = "d3c48237b9604c5a4702de6b824e02006c3214327564636aef27c1028a8fa0ed"
 dependencies = [
  "regex",
 ]
@@ -3099,9 +3000,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.3"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
+checksum = "b64f40e5e03e0d54f03845c8197d0291253cdbedfb1cb46b13c2c117554a9f4c"
 
 [[package]]
 name = "lock_api"
@@ -3251,6 +3152,15 @@ name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
 ]
@@ -3499,9 +3409,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.51"
+version = "0.10.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
+checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3531,9 +3441,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.86"
+version = "0.9.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
+checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
 dependencies = [
  "cc",
  "libc",
@@ -3761,9 +3671,9 @@ checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "pest"
-version = "2.5.7"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1403e8401ad5dedea73c626b99758535b342502f8d1e361f4a2dd952749122"
+checksum = "e68e84bfb01f0507134eac1e9b410a12ba379d064eab48c50ba4ce329a527b70"
 dependencies = [
  "thiserror",
  "ucd-trie",
@@ -3841,12 +3751,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pico-args"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
-
-[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3894,7 +3798,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.4",
+ "der 0.7.5",
  "spki 0.7.1",
 ]
 
@@ -3915,11 +3819,11 @@ dependencies = [
  "axum 0.5.17",
  "cargo-husky",
  "chrono",
- "clap 4.2.4",
+ "clap",
  "dotenv",
  "ethers",
  "ethers-contract",
- "ethers-core 2.0.3",
+ "ethers-core 2.0.4",
  "ethers-derive-eip712",
  "graphcast-sdk",
  "graphql_client 0.9.0",
@@ -4307,9 +4211,9 @@ checksum = "a5996294f19bd3aae0453a862ad728f60e6600695733dd5df01da90c54363a3c"
 
 [[package]]
 name = "reqwest"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
+checksum = "13293b639a097af28fc8a90f22add145a9c954e49d77da06263d58cf44d5fb91"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -4460,9 +4364,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.13"
+version = "0.37.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
+checksum = "8bbfc1d1c7c40c01715f47d71444744a81669ca84e8b63e25a55e169b1f86433"
 dependencies = [
  "bitflags",
  "errno",
@@ -4486,9 +4390,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07180898a28ed6a7f7ba2311594308f595e3dd2e3c3812fa0a80a47b45f17e5d"
+checksum = "c911ba11bc8433e811ce56fde130ccf32f5127cab0e0194e9c68c5a5b671791e"
 dependencies = [
  "log",
  "ring",
@@ -4579,9 +4483,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfdffd972d76b22f3d7f81c8be34b2296afd3a25e0a547bd9abe340a4dbbe97"
+checksum = "dfdef77228a4c05dc94211441595746732131ad7f6530c6c18f045da7b7ab937"
 dependencies = [
  "cfg-if",
  "derive_more",
@@ -4591,9 +4495,9 @@ dependencies = [
 
 [[package]]
 name = "scale-info-derive"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61fa974aea2d63dd18a4ec3a49d59af9f34178c73a4f56d2f18205628d00681e"
+checksum = "53012eae69e5aa5c14671942a5dd47de59d4cdcff8532a6dd0e081faf1119482"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -4665,7 +4569,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0aec48e813d6b90b15f0b8948af3c63483992dee44c03e9930b3eebdabe046e"
 dependencies = [
  "base16ct 0.2.0",
- "der 0.7.4",
+ "der 0.7.5",
  "generic-array",
  "pkcs8 0.10.2",
  "subtle",
@@ -5019,7 +4923,7 @@ checksum = "8401d52ffeed628f8e428f47f6c10f49d787b07bbfe85d2818565b7f88ca7b94"
 dependencies = [
  "async-recursion",
  "async-trait",
- "axum 0.6.16",
+ "axum 0.6.18",
  "base64 0.21.0",
  "bytes",
  "chrono",
@@ -5120,7 +5024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37a5be806ab6f127c3da44b7378837ebf01dadca8510a0e572460216b228bd0e"
 dependencies = [
  "base64ct",
- "der 0.7.4",
+ "der 0.7.5",
 ]
 
 [[package]]
@@ -5210,7 +5114,7 @@ checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
 dependencies = [
  "anyhow",
  "cfg-if",
- "clap 3.2.23",
+ "clap",
  "console 0.14.1",
  "dialoguer",
  "fs2",
@@ -5442,9 +5346,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.27.0"
+version = "1.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0de47a4eecbe11f498978a9b29d792f0d2692d1dd003650c24c76510e3bc001"
+checksum = "c3c786bf8134e5a3a166db9b29ab8f48134739014a3eca7bc6bfa95d673b136f"
 dependencies = [
  "autocfg",
  "bytes",
@@ -5457,14 +5361,14 @@ dependencies = [
  "socket2",
  "tokio-macros",
  "tracing",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.0.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5498,15 +5402,15 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0d409377ff5b1e3ca6437aa86c1eb7d40c134bfec254e44c830defa92669db5"
 dependencies = [
- "rustls 0.21.0",
+ "rustls 0.21.1",
  "tokio",
 ]
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.12"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fb52b74f05dbf495a8fba459fdc331812b96aa086d9eb78101fa0d4569c3313"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -5544,9 +5448,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5681,13 +5585,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+checksum = "0f57e3ca2a01450b1a921183a9c9cbfda207fd822cef4ccb00a65402cbba7a74"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -5737,9 +5641,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6176eae26dd70d0c919749377897b54a9276bd7061339665dd68777926b5a70"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5910,12 +5814,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
@@ -6321,9 +6219,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["network-programming", "web-programming::http-client"]
 default-run = "poi-radio"
 
 [dependencies]
-graphcast-sdk = "0.1.1"
+graphcast-sdk = { git = "https://github.com/graphops/graphcast-sdk" }
 prost = "0.11"
 once_cell = "1.15"
 chrono = "0.4"
@@ -39,7 +39,7 @@ secp256k1 = "0.25.0"
 hex = "0.4.3"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-autometrics = {version = "0.3.2", features = ["prometheus-exporter", ]}
+autometrics = { version = "0.3.2", features = ["prometheus-exporter"] }
 axum = "0.5"
 prometheus = "0.13.3"
 # async-graphql = { version = "5.0", features = ["chrono", "dataloader"] }
@@ -50,10 +50,10 @@ async-graphql = "4.0.16"
 async-graphql-axum = "4.0.16"
 metrics = "0.20.1"
 metrics-exporter-prometheus = "0.11.0"
-opentelemetry = {version = "0.18.0", features = ["rt-tokio"]}
-opentelemetry-jaeger = {version = "0.17.0", features = ["rt-tokio"]}
+opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
+opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"] }
 tracing-opentelemetry = "0.18.0"
-clap = { version = "4.1.6", features = ["derive"] }
+clap = { version = "3.2.23", features = ["derive", "env"] }
 
 [[bin]]
 name = "integration-tests"

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -4,7 +4,7 @@ pub mod utils;
 
 use checks::simple_tests::run_simple_tests;
 use dotenv::dotenv;
-use graphcast_sdk::config::Config;
+use poi_radio::config::Config;
 use poi_radio::CONFIG;
 use setup::basic::run_basic_instance;
 use std::sync::{Arc, Mutex as SyncMutex};

--- a/integration-tests/src/setup/test_radio.rs
+++ b/integration-tests/src/setup/test_radio.rs
@@ -8,7 +8,7 @@ use chrono::Utc;
 
 use ethers::signers::{LocalWallet, Signer};
 use graphcast_sdk::graphcast_agent::message_typing::{BuildMessageError, GraphcastMessage};
-use graphcast_sdk::graphcast_agent::{GraphcastAgent, GraphcastAgentError};
+use graphcast_sdk::graphcast_agent::{GraphcastAgent, GraphcastAgentConfig, GraphcastAgentError};
 use graphcast_sdk::graphql::client_graph_node::update_chainhead_blocks;
 use graphcast_sdk::graphql::client_network::query_network_subgraph;
 use graphcast_sdk::graphql::client_registry::query_registry_indexer;
@@ -133,25 +133,24 @@ pub async fn run_test_radio<S, A, P>(
         my_stake
     );
 
-    let graphcast_agent = GraphcastAgent::new(
+    let graphcast_agent_config = GraphcastAgentConfig::new(
         private_key,
         radio_name,
-        &registry_subgraph,
-        &network_subgraph,
-        &graph_node_endpoint,
-        vec![],
-        Some("testnet"),
-        runtime_config.subgraphs.clone().unwrap_or(vec![
-            MOCK_SUBGRAPH_MAINNET.to_string(),
-            MOCK_SUBGRAPH_GOERLI.to_string(),
-        ]),
+        registry_subgraph.clone(),
+        network_subgraph.clone(),
+        graph_node_endpoint.clone(),
+        None,
+        Some("testnet".to_owned()),
+        runtime_config.subgraphs.clone(),
         None,
         None,
         Some(get_random_port()),
         None,
     )
     .await
-    .unwrap();
+    .expect("Failed to create GraphcastAgentConfig");
+
+    let graphcast_agent = GraphcastAgent::new(graphcast_agent_config).await.unwrap();
 
     _ = GRAPHCAST_AGENT.set(graphcast_agent);
     _ = MESSAGES.set(Arc::new(SyncMutex::new(vec![])));

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,294 @@
+use clap::Parser;
+use ethers::signers::WalletError;
+use graphcast_sdk::build_wallet;
+use graphcast_sdk::graphcast_agent::GraphcastAgentConfig;
+use graphcast_sdk::graphcast_agent::GraphcastAgentError;
+use graphcast_sdk::graphcast_id_address;
+use graphcast_sdk::init_tracing;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+
+#[derive(clap::ValueEnum, Clone, Debug, Serialize, Deserialize)]
+pub enum CoverageLevel {
+    Minimal,
+    OnChain,
+    Comprehensive,
+}
+
+#[derive(Clone, Debug, Parser, Serialize, Deserialize)]
+#[clap(
+    name = "poi-radio",
+    about = "Cross-check POIs with other Indexer in real time",
+    author = "GraphOps"
+)]
+pub struct Config {
+    #[clap(
+        long,
+        value_name = "ENDPOINT",
+        env = "GRAPH_NODE_STATUS_ENDPOINT",
+        help = "API endpoint to the Graph Node Status Endpoint"
+    )]
+    pub graph_node_endpoint: String,
+    #[clap(
+        long,
+        value_name = "KEY",
+        value_parser = Config::parse_key,
+        env = "PRIVATE_KEY",
+        hide_env_values = true,
+        help = "Private key to the Graphcast ID wallet (Precendence over mnemonics)",
+    )]
+    pub private_key: Option<String>,
+    #[clap(
+        long,
+        value_name = "KEY",
+        value_parser = Config::parse_key,
+        env = "MNEMONIC",
+        hide_env_values = true,
+        help = "Mnemonic to the Graphcast ID wallet (first address of the wallet is used; Only one of private key or mnemonic is needed)",
+    )]
+    pub mnemonic: Option<String>,
+    #[clap(
+        long,
+        value_name = "SUBGRAPH",
+        env = "REGISTRY_SUBGRAPH",
+        help = "Subgraph endpoint to the Graphcast Registry",
+        default_value = "https://api.thegraph.com/subgraphs/name/hopeyen/graphcast-registry-goerli"
+    )]
+    pub registry_subgraph: String,
+    #[clap(
+        long,
+        value_name = "SUBGRAPH",
+        env = "NETWORK_SUBGRAPH",
+        help = "Subgraph endpoint to The Graph network subgraph",
+        default_value = "https://gateway.testnet.thegraph.com/network"
+    )]
+    pub network_subgraph: String,
+    #[clap(
+        long,
+        default_value = "testnet",
+        value_name = "NAME",
+        env = "GRAPHCAST_NETWORK",
+        help = "Supported Graphcast networks: mainnet, testnet",
+        possible_values = ["testnet", "mainnet"]
+    )]
+    pub graphcast_network: String,
+    #[clap(
+        long,
+        value_name = "[TOPIC]",
+        value_delimiter = ',',
+        env = "TOPICS",
+        help = "Comma separated static list of content topics to subscribe to (Static list to include)"
+    )]
+    pub topics: Vec<String>,
+    #[clap(
+        long,
+        value_name = "COVERAGE",
+        value_enum,
+        default_value = "on-chain",
+        env = "COVERAGE",
+        help = "Toggle for topic coverage level",
+        long_help = "Topic coverage level\ncomprehensive: Subscribe to on-chain topics, user defined static topics, and additional topics\n
+            on-chain: Subscribe to on-chain topics and user defined static topics\nminimal: Only subscribe to user defined static topics.\n
+            Default is set to on-chain coverage"
+    )]
+    pub coverage: CoverageLevel,
+    #[clap(
+        long,
+        min_values = 0,
+        default_value = "120",
+        value_name = "COLLECT_MESSAGE_DURATION",
+        env = "COLLECT_MESSAGE_DURATION",
+        help = "Set the minimum duration to wait for a topic message collection"
+    )]
+    pub collect_message_duration: i64,
+    #[clap(
+        long,
+        value_name = "WAKU_HOST",
+        help = "Host for the GraphQL HTTP server",
+        env = "WAKU_HOST"
+    )]
+    pub waku_host: Option<String>,
+    #[clap(
+        long,
+        value_name = "WAKU_PORT",
+        help = "Port for the GraphQL HTTP server",
+        env = "WAKU_PORT"
+    )]
+    pub waku_port: Option<String>,
+    #[clap(
+        long,
+        value_name = "KEY",
+        env = "WAKU_NODE_KEY",
+        hide_env_values = true,
+        help = "Private key to the Waku node id"
+    )]
+    pub waku_node_key: Option<String>,
+    #[clap(
+        long,
+        value_name = "KEY",
+        env = "WAKU_ADDRESS",
+        hide_env_values = true,
+        help = "Advertised address to be connected among the Waku peers"
+    )]
+    pub waku_addr: Option<String>,
+    #[clap(
+        long,
+        value_name = "NODE_ADDRESSES",
+        help = "Comma separated static list of waku boot nodes to connect to",
+        env = "BOOT_NODE_ADDRESSES"
+    )]
+    pub boot_node_addresses: Vec<String>,
+    #[clap(
+        long,
+        value_name = "WAKU_LOG_LEVEL",
+        help = "Waku node logging configuration",
+        env = "WAKU_LOG_LEVEL"
+    )]
+    pub waku_log_level: Option<String>,
+    #[clap(
+        long,
+        value_name = "LOG_LEVEL",
+        default_value = "info",
+        help = "logging configurationt to set as RUST_LOG",
+        env = "RUST_LOG"
+    )]
+    pub log_level: String,
+    #[clap(
+        long,
+        value_name = "SLACK_TOKEN",
+        help = "Slack bot API token",
+        env = "SLACK_TOKEN"
+    )]
+    pub slack_token: Option<String>,
+    #[clap(
+        long,
+        value_name = "SLACK_CHANNEL",
+        help = "Name of Slack channel to send messages to (has to be a public channel)",
+        env = "SLACK_CHANNEL"
+    )]
+    pub slack_channel: Option<String>,
+    #[clap(
+        long,
+        value_name = "INSTANCE",
+        // Basic instance runs with default configs, invalid_payload sends a malformed message, divergent sends an unexpected nPOI value
+        possible_values = &["basic", "invalid_payload", "divergent", "invalid_hash", "invalid_nonce"],
+        help = "Instance to run (integration tests)"
+    )]
+    pub instance: Option<String>,
+    #[clap(
+        long,
+        value_name = "CHECK",
+        possible_values = &[
+            "simple_tests",
+            "invalid_sender",
+            "poi_divergence_remote",
+            "poi_divergence_local",
+            "invalid_messages"
+        ],
+        help = "Check to run (integration tests)"
+    )]
+    pub check: Option<String>,
+    #[clap(
+        long,
+        value_name = "DISCORD_WEBHOOK",
+        help = "Discord webhook URL to send messages to",
+        env = "DISCORD_WEBHOOK"
+    )]
+    pub discord_webhook: Option<String>,
+    #[clap(
+        long,
+        value_name = "METRICS_HOST",
+        help = "If set, the Radio will expose Prometheus metrics on the given host (off by default). This requires having a local Prometheus server running and scraping metrics on the given port.",
+        env = "METRICS_HOST"
+    )]
+    pub metrics_host: Option<String>,
+    #[clap(
+        long,
+        value_name = "METRICS_PORT",
+        help = "If set, the Radio will expose Prometheus metrics on the given port (off by default). This requires having a local Prometheus server running and scraping metrics on the given port.",
+        env = "METRICS_PORT"
+    )]
+    pub metrics_port: Option<u16>,
+    #[clap(
+        long,
+        value_name = "SERVER_HOST",
+        help = "If set, the Radio will expose API service on the given host (off by default).",
+        env = "SERVER_HOST"
+    )]
+    pub server_host: Option<String>,
+    #[clap(
+        long,
+        value_name = "SERVER_PORT",
+        help = "If set, the Radio will expose API service on the given port (off by default).",
+        env = "SERVER_PORT"
+    )]
+    pub server_port: Option<u16>,
+}
+
+impl Config {
+    /// Parse config arguments
+    pub fn args() -> Self {
+        // TODO: load config file before parse (maybe add new level of subcommands)
+        let config = Config::parse();
+        std::env::set_var("RUST_LOG", config.log_level.clone());
+        // Enables tracing under RUST_LOG variable
+        init_tracing().expect("Could not set up global default subscriber for logger, check environmental variable `RUST_LOG` or the CLI input `log-level`");
+        config
+    }
+
+    /// Validate that private key as an Eth wallet
+    fn parse_key(value: &str) -> Result<String, WalletError> {
+        // The wallet can be stored instead of the original private key
+        let wallet = build_wallet(value)?;
+        let addr = graphcast_id_address(&wallet);
+        info!("Resolved Graphcast id: {}", addr);
+        Ok(String::from(value))
+    }
+
+    /// Private key takes precedence over mnemonic
+    pub fn wallet_input(&self) -> Result<&String, ConfigError> {
+        match (&self.private_key, &self.mnemonic) {
+            (Some(p), _) => Ok(p),
+            (_, Some(m)) => Ok(m),
+            _ => Err(ConfigError::ValidateInput(
+                "Must provide either private key or mnemonic".to_string(),
+            )),
+        }
+    }
+
+    pub async fn to_graphcast_agent_config(
+        &self,
+        radio_name: &'static str,
+    ) -> Result<GraphcastAgentConfig, GraphcastAgentError> {
+        let wallet_key = self.wallet_input().unwrap().to_string();
+        let topics = self.topics.clone();
+
+        GraphcastAgentConfig::new(
+            wallet_key,
+            radio_name,
+            self.registry_subgraph.clone(),
+            self.network_subgraph.clone(),
+            self.graph_node_endpoint.clone(),
+            Some(self.boot_node_addresses.clone()),
+            Some(self.graphcast_network.to_owned()),
+            Some(topics),
+            self.waku_node_key.clone(),
+            self.waku_host.clone(),
+            self.waku_port.clone(),
+            self.waku_addr.clone(),
+        )
+        .await
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("Validate the input: {0}")]
+    ValidateInput(String),
+    #[error("Generate JSON representation of the config file: {0}")]
+    GenerateJson(serde_json::Error),
+    #[error("Toml file error: {0}")]
+    ReadStr(std::io::Error),
+    #[error("Unknown error: {0}")]
+    Other(anyhow::Error),
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use async_graphql::{Error, ErrorExtensions, SimpleObject};
 use autometrics::autometrics;
+use config::{Config, CoverageLevel};
 use ethers_contract::EthAbiType;
 use ethers_core::types::transaction::eip712::Eip712;
 use ethers_derive_eip712::*;
@@ -17,9 +18,7 @@ use tokio::signal;
 use tracing::{error, trace};
 
 use graphcast_sdk::{
-    config::{Config, CoverageLevel},
-    graphcast_agent::GraphcastAgentError,
-    graphql::client_graph_node::get_indexing_statuses,
+    graphcast_agent::GraphcastAgentError, graphql::client_graph_node::get_indexing_statuses,
 };
 use graphcast_sdk::{
     graphcast_agent::{
@@ -34,6 +33,7 @@ use crate::attestation::AttestationError;
 use crate::metrics::{CACHED_MESSAGES, VALIDATED_MESSAGES};
 
 pub mod attestation;
+pub mod config;
 pub mod graphql;
 pub mod metrics;
 pub mod server;


### PR DESCRIPTION
### Description

Moving the Config struct that is responsible for parsing env vars from the command line or env variables away from the SDK and into the Radio. Now the only way to pass these variables into the SDK is through GraphcastAgent::new.

Corresponding SDK PR - https://github.com/graphops/graphcast-sdk/issues/188

### Issue link (if applicable)
https://github.com/graphops/graphcast-sdk/issues/188

### Checklist

- [x] Have you tested your changes?
- [x] Does this PR include changes that require our documentation to be updated, if so, have you created a PR on the docs repo to make the necessary changes? - **this PR should not require docs changes**
