### PR TITLE
fix radio name constant in main

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -5,7 +5,7 @@ pub mod utils;
 use checks::simple_tests::run_simple_tests;
 use dotenv::dotenv;
 use poi_radio::config::Config;
-use poi_radio::CONFIG;
+use poi_radio::{CONFIG, RADIO_NAME};
 use setup::basic::run_basic_instance;
 use std::sync::{Arc, Mutex as SyncMutex};
 use std::{env, str::FromStr};
@@ -77,6 +77,7 @@ pub async fn main() {
     let args = Config::args();
 
     _ = CONFIG.set(Arc::new(SyncMutex::new(args)));
+    _ = RADIO_NAME.set("test-radio");
 
     let test_instance = env::var("INSTANCE").ok();
     let test_check = env::var("CHECK").ok();

--- a/integration-tests/src/setup/test_radio.rs
+++ b/integration-tests/src/setup/test_radio.rs
@@ -26,7 +26,7 @@ use poi_radio::graphql::query_graph_node_poi;
 use poi_radio::metrics::{handle_serve_metrics, CACHED_MESSAGES};
 use poi_radio::{
     attestation::Attestation, chainhead_block_str, radio_msg_handler, MessagesVec, OperationError,
-    RadioPayloadMessage, GRAPHCAST_AGENT, MESSAGES,
+    RadioPayloadMessage, GRAPHCAST_AGENT, MESSAGES, RADIO_NAME,
 };
 use rand::{thread_rng, Rng};
 use secp256k1::SecretKey;
@@ -117,7 +117,7 @@ pub async fn run_test_radio<S, A, P>(
     let private_key = env::var("PRIVATE_KEY").unwrap();
 
     // TODO: Add something random and unique here to avoid noise form other operators
-    let radio_name: &str = "test-poi-radio";
+    _ = RADIO_NAME.set("test-poi-radio");
 
     let my_address =
         query_registry_indexer(registry_subgraph.clone(), graphcast_id_address(&wallet))
@@ -135,7 +135,7 @@ pub async fn run_test_radio<S, A, P>(
 
     let graphcast_agent_config = GraphcastAgentConfig::new(
         private_key,
-        radio_name,
+        RADIO_NAME.get().expect("RADIO_NAME required"),
         registry_subgraph.clone(),
         network_subgraph.clone(),
         graph_node_endpoint.clone(),
@@ -346,7 +346,14 @@ pub async fn run_test_radio<S, A, P>(
             }
         }
 
-        log_summary(blocks_str, num_topics, send_ops, compare_ops, radio_name).await;
+        log_summary(
+            blocks_str,
+            num_topics,
+            send_ops,
+            compare_ops,
+            RADIO_NAME.get().unwrap(),
+        )
+        .await;
 
         setup_mock_server(
             round_to_nearest(Utc::now().timestamp()).try_into().unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,18 +20,18 @@ use poi_radio::config::Config;
 use poi_radio::metrics::handle_serve_metrics;
 use poi_radio::operation::gossip_poi;
 use poi_radio::server::run_server;
-use poi_radio::CONFIG;
 use poi_radio::{
     attestation::LocalAttestationsMap, chainhead_block_str, generate_topics, radio_msg_handler,
     GRAPHCAST_AGENT, MESSAGES,
 };
+use poi_radio::{CONFIG, RADIO_NAME};
 
 #[macro_use]
 extern crate partial_application;
 
 #[tokio::main]
 async fn main() {
-    let radio_name: &str = "poi-radio";
+    _ = RADIO_NAME.set("poi-radio");
     dotenv().ok();
 
     // Parse basic configurations
@@ -50,7 +50,7 @@ async fn main() {
     debug!("Initializing Graphcast Agent");
 
     let graphcast_agent_config = radio_config
-        .to_graphcast_agent_config(radio_name)
+        .to_graphcast_agent_config(RADIO_NAME.get().expect("RADIO_NAME required."))
         .await
         .unwrap_or_else(|e| panic!("Could not create GraphcastAgentConfig: {e}"));
 


### PR DESCRIPTION
### Description

`RADIO_NAME` is now required as a global constant. Alternatively it can be a function that simply returns the name.

### Issue link (if applicable)

hot-fix

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
