### PR TITLE
Attestation result ratio str query

### DIFF
--- a/src/attestation/mod.rs
+++ b/src/attestation/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     metrics::{
         ACTIVE_INDEXERS, DIVERGING_SUBGRAPHS, INDEXER_COUNT_BY_NPOI, LOCAL_NPOIS_TO_COMPARE,
     },
-    OperationError, RadioPayloadMessage, CONFIG,
+    OperationError, RadioPayloadMessage, CONFIG, MESSAGES,
 };
 
 /// A wrapper around an attested NPOI, tracks Indexers that have sent it plus their accumulated stake
@@ -655,7 +655,7 @@ pub async fn log_summary(
     DIVERGING_SUBGRAPHS.set(divergent_strings.len().try_into().unwrap());
 
     info!(
-        "Operation summary for\n{}: {}:\n{}: {}\n{}: {}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {}\n{}: {}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}",
+        "Operation summary for\n{}: {}:\n{}: {}\n{}: {}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {}\n{}: {}\n{}: {}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}\n{}: {:#?}",
         "Chainhead blocks",
         blocks_str.clone(),
         "# of deployments tracked",
@@ -664,20 +664,22 @@ pub async fn log_summary(
         send_success.len(),
         "# of deployments waiting for next message interval",
         skip_repeated.len(),
-        "Deployments catching up to chainhead",
-        trigger_failed,
+        "# of deployments catching up to chainhead",
+        trigger_failed.len(),
         "Deployments failed to build message",
         build_errors,
+        "# of messages cached",
+        MESSAGES.get().unwrap().lock().unwrap().len(),
         "# of deployments actively cross-checked",
         match_strings.len() + divergent_strings.len(),
         "# of successful attestations",
         match_strings.len(),
-        "# of deployments without remote attestation",
+        "# of deployments without matching attestations",
         not_found_strings.len(),
+        "# of deployment waiting for comparison trigger",
+        cmp_trigger_failed.len(),
         "Divergence",
         divergent_strings,
-        "Compare trigger out of bound",
-        cmp_trigger_failed,
         "Attestation failed",
         attestation_failed,
         "Comparison failed",

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ async fn main() {
     let mut gossip_poi_interval = interval(Duration::from_secs(30));
 
     let iteration_timeout = Duration::from_secs(180);
-    let update_timeout = Duration::from_secs(15);
+    let update_timeout = Duration::from_secs(10);
     let gossip_timeout = Duration::from_secs(150);
 
     // Skip a main loop iteration when hit timeout


### PR DESCRIPTION
### Description

(Repeated PR bc of stupidity with git rebase: https://github.com/graphops/poi-radio/pull/133)

### Description

Provide a clear aggregation of the attestations from remote messages with optional filters

```
  stakeRatio(filter: {deployment: "__", blockNumber: "___"}){
    deployment
    blockNumber
    compareRatio
  }
  
  senderRatio{
    deployment
    blockNumber
    compareRatio
  }
  
```

will provide a string of compare Ratio. 

Examples with sender ratio

- `x/y!/z` where x, y, z are sorted by descending stake weights, and `!` indicates the entry that correspond to the local result. 

- `2/0!` means there are 2 indexers attesting with higher sum of stake weight, and no other indexer has the same nPOI as us.

- `8!` means there are 8 other indexers agreeing with us. 

### Issue link (if applicable)

Improvement for #93 

### Checklist
- [ ] Are tests up-to-date with the new changes? 
- [ ] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)
