### PR TITLE
State persistence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,10 @@ serde = "1.0.163"
 serde_json = "1.0.96"
 sha3 = "0.10.8"
 tokio = { version = "1.28.1", features = ["full", "rt"] }
-anyhow = "1.0.71"
+# tokio = { version = "1.28", features = ["full", "tracing", "rt", "parking_lot"] }
+anyhow = "1.0"
 graphql_client = "0.9.0"
-serde_derive = "1.0.163"
+serde_derive = "1.0"
 reqwest = { version = "0.11.17", features = ["json"] }
 thiserror = "1.0.40"
 regex = "1.8.1"
@@ -57,6 +58,7 @@ opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
 opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio"] }
 tracing-opentelemetry = "0.18.0"
 clap = { version = "3.2.25", features = ["derive", "env"] }
+# console-subscriber = "0.1.9"
 
 [dev-dependencies]
 criterion = {version = "0.4", features = [ "async", "async_futures" ]}

--- a/benches/gossips.rs
+++ b/benches/gossips.rs
@@ -51,6 +51,7 @@ fn gossip_poi_bench(c: &mut Criterion) {
         server_host: None,
         server_port: None,
         log_format: String::from("pretty"),
+        persistence_file_path: None,
     });
     _ = black_box(CONFIG.set(Arc::new(SyncMutex::new(config))));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -210,6 +210,13 @@ pub struct Config {
     pub server_port: Option<u16>,
     #[clap(
         long,
+        value_name = "PERSISTENCE_FILE_PATH",
+        help = "If set, the Radio will periodically store states of the program to the file in json format",
+        env = "PERSISTENCE_FILE_PATH"
+    )]
+    pub persistence_file_path: Option<String>,
+    #[clap(
+        long,
         value_name = "LOG_FORMAT",
         env = "LOG_FORMAT",
         help = "Support logging formats: pretty, json, full, compact",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 use async_graphql::{Error, ErrorExtensions, SimpleObject};
+
 use autometrics::autometrics;
 use config::{Config, CoverageLevel};
 use ethers_contract::EthAbiType;
@@ -38,6 +39,7 @@ pub mod graphql;
 pub mod metrics;
 pub mod operation;
 pub mod server;
+pub mod state;
 
 pub type MessagesVec = OnceCell<Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>>;
 
@@ -269,6 +271,10 @@ impl ErrorExtensions for OperationError {
     fn extend(&self) -> Error {
         Error::new(format!("{}", self))
     }
+}
+
+pub fn clear_all_messages() {
+    _ = MESSAGES.set(Arc::new(SyncMutex::new(vec![])));
 }
 
 #[cfg(test)]

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -222,7 +222,6 @@ pub async fn message_comparison(
         .filter(|&m| m.block_number == compare_block && m.nonce <= collect_window_end)
         .cloned()
         .collect();
-
     debug!(
         "Comparing validated and filtered messages:\n{}: {}\n{}: {}\n{}: {}\n{}: {}\n{}: {}\n{}: {}",
         "Deployment",
@@ -335,7 +334,6 @@ pub async fn compare_poi(
             .unwrap()
             .collect_message_duration;
         let id_cloned = id.clone();
-
         let registry_subgraph = CONFIG
             .get()
             .unwrap()

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,0 +1,222 @@
+use std::{
+    collections::HashMap,
+    fs::{remove_file, File},
+    io::{BufReader, Write},
+};
+
+use graphcast_sdk::graphcast_agent::message_typing::GraphcastMessage;
+
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex as SyncMutex};
+use tokio::sync::Mutex as AsyncMutex;
+use tracing::warn;
+
+use crate::{attestation::Attestation, RadioPayloadMessage};
+
+type Local = Arc<AsyncMutex<HashMap<String, HashMap<u64, Attestation>>>>;
+type Remote = Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>;
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct PersistedState {
+    local_attestations: HashMap<String, HashMap<u64, Attestation>>,
+    remote_messages: Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>,
+}
+
+impl PersistedState {
+    pub fn new(
+        local: Option<HashMap<String, HashMap<u64, Attestation>>>,
+        remote: Option<Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>>>,
+    ) -> PersistedState {
+        let local_attestations = local.unwrap_or(HashMap::new());
+        let remote_messages = remote.unwrap_or(Arc::new(SyncMutex::new(vec![])));
+
+        PersistedState {
+            local_attestations,
+            remote_messages,
+        }
+    }
+
+    /// Optional updates for either local_attestations or remote_messages without requiring either to be in-scope
+    pub async fn update(
+        &self,
+        local_attestations: Option<Local>,
+        remote_messages: Option<Remote>,
+    ) -> PersistedState {
+        let local_attestations: HashMap<String, HashMap<u64, Attestation>> =
+            match local_attestations {
+                None => self.local_attestations.clone(),
+                Some(l) => l.lock().await.clone(),
+            };
+        let remote_messages = match remote_messages {
+            None => self.remote_messages.clone(),
+            Some(r) => r,
+        };
+        PersistedState {
+            local_attestations,
+            remote_messages,
+        }
+    }
+
+    /// Getter for local_attestations
+    pub fn local_attestations(&self) -> HashMap<String, HashMap<u64, Attestation>> {
+        self.local_attestations.clone()
+    }
+
+    /// Getter for one local_attestation
+    pub fn local_attestation(&self, deployment: String, block_number: u64) -> Option<Attestation> {
+        match self.local_attestations.get(&deployment) {
+            None => None,
+            Some(blocks_map) => blocks_map.get(&block_number).cloned(),
+        }
+    }
+
+    /// Getter for remote_messages
+    pub fn remote_messages(&self) -> Arc<SyncMutex<Vec<GraphcastMessage<RadioPayloadMessage>>>> {
+        self.remote_messages.clone()
+    }
+
+    /// Update file cache
+    pub fn update_cache(&self, path: &str) {
+        // Attempt to serialize state to JSON
+        let state_json = serde_json::to_string(&self.clone())
+            .unwrap_or_else(|_| "Could not serialize state to JSON".to_owned());
+
+        // Write state to file
+        let mut file = File::create(path).unwrap();
+        file.write_all(state_json.as_bytes()).unwrap();
+    }
+
+    /// Load cache into persisted state
+    pub fn load_cache(path: &str) -> PersistedState {
+        let file = match File::open(path) {
+            Ok(f) => f,
+            Err(_) => {
+                warn!("Could not find persisted state file, create a state");
+                // No state persisted, create new
+                return PersistedState::new(None, None);
+            }
+        };
+
+        let reader: BufReader<File> = BufReader::new(file);
+        let state: PersistedState = match serde_json::from_reader(reader) {
+            Ok(s) => s,
+            Err(e) => {
+                // Persisted state can't be parsed, create a new one
+                warn!(
+                    "Could not find persisted state file, created a new state: {}",
+                    e.to_string()
+                );
+                PersistedState::new(None, None)
+            }
+        };
+        state
+    }
+
+    /// Clean up
+    pub fn delete_cache(path: &str) {
+        _ = remove_file(path);
+    }
+}
+
+//TODO: panic hook for updating the cache file before exiting the program
+// /// Set up panic hook to store persisted state
+// pub fn panic_hook<'a>(file_path: &str){
+//     let path = String::from_str(file_path).expect("Invalid file path provided");
+//     panic::set_hook(Box::new(move |panic_info| panic_cache(panic_info, &path)));
+// }
+
+// pub fn panic_cache(panic_info: &PanicInfo<'_>, file_path: &str) {
+//     update_cache(file_path);
+//     // Log panic information and program state
+//     eprintln!("Panic occurred! Panic info: {:?}", panic_info);
+// }
+
+#[cfg(test)]
+mod tests {
+    use graphcast_sdk::networks::NetworkName;
+
+    use crate::attestation::save_local_attestation;
+
+    use super::*;
+
+    /// Tests for load, update, and store cache
+    #[tokio::test]
+    async fn test_state_cache() {
+        let path = "test-state.json";
+        PersistedState::delete_cache(path);
+
+        let mut state = PersistedState::load_cache(path);
+        assert!(state.local_attestations.is_empty());
+        assert!(state.remote_messages.lock().unwrap().is_empty());
+
+        let local_attestations = Arc::new(AsyncMutex::new(HashMap::new()));
+        let messages = Arc::new(SyncMutex::new(Vec::new()));
+        save_local_attestation(
+            local_attestations.clone(),
+            "npoi-x".to_string(),
+            "0xa1".to_string(),
+            0,
+        )
+        .await;
+
+        save_local_attestation(
+            local_attestations.clone(),
+            "npoi-y".to_string(),
+            "0xa1".to_string(),
+            1,
+        )
+        .await;
+
+        save_local_attestation(
+            local_attestations.clone(),
+            "npoi-z".to_string(),
+            "0xa2".to_string(),
+            2,
+        )
+        .await;
+
+        let hash: String = "QmWECgZdP2YMcV9RtKU41GxcdW8EGYqMNoG98ubu5RGN6U".to_string();
+        let content: String =
+            "0xa6008cea5905b8b7811a68132feea7959b623188e2d6ee3c87ead7ae56dd0eae".to_string();
+        let nonce: i64 = 123321;
+        let block_number: u64 = 0;
+        let block_hash: String = "0xblahh".to_string();
+        let radio_msg = RadioPayloadMessage::new(hash.clone(), content);
+        let sig: String = "4be6a6b7f27c4086f22e8be364cbdaeddc19c1992a42b08cbe506196b0aafb0a68c8c48a730b0e3155f4388d7cc84a24b193d091c4a6a4e8cd6f1b305870fae61b".to_string();
+        let msg = GraphcastMessage::new(
+            hash,
+            Some(radio_msg),
+            nonce,
+            NetworkName::Goerli,
+            block_number,
+            block_hash,
+            sig,
+        )
+        .expect("Shouldn't get here since the message is purposefully constructed for testing");
+        messages.lock().unwrap().push(msg);
+
+        state = state
+            .update(Some(local_attestations.clone()), Some(messages.clone()))
+            .await;
+        state.update_cache(path);
+
+        let state = PersistedState::load_cache(path);
+        assert!(state.remote_messages.lock().unwrap().len() == 1);
+        assert!(!state.local_attestations.is_empty());
+        assert!(state.local_attestations.len() == 2);
+        assert!(state.local_attestations.get("0xa1").unwrap().len() == 2);
+        assert!(state.local_attestations.get("0xa2").unwrap().len() == 1);
+        assert!(
+            state
+                .local_attestations
+                .get("0xa1")
+                .unwrap()
+                .get(&0)
+                .unwrap()
+                .npoi
+                == *"npoi-x"
+        );
+
+        PersistedState::delete_cache(path);
+    }
+}


### PR DESCRIPTION
### Description

To enable the radio to operate seemlessly between sessions, this PR
- adds `PersistedState` struct to track local attestations and remote messages, it should later track comparison result as well.
- adds periodic event to update the persisted state cache.
- allows users to provide a file path that retains the radio state for local attestations and remote messages.
- enables integrations tests to query radio states without going inside of radio operations.
- enables future functional refactoring of radio states

### Issue link (if applicable)

Resolves #113

### Checklist
- [x] Are tests up-to-date with the new changes? 
- [x] Are docs up-to-date with the new changes? (Open PR on docs repo if necessary)

@test_pls
