### PR TITLE
refactor: remove 'v' prefix from release tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
   push:
     tags:
-      - "v*.*.*"
+      - "*.*.*"
 
 env:
   REGISTRY: ghcr.io
@@ -16,12 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - 
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v3
 
-      -
-        name: Docker meta
+      - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
         with:
@@ -55,4 +53,3 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           dockerfile: Dockerfile
-

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-VERSION="v$(cargo metadata --quiet --format-version 1 | jq -r '.packages[] | select(.name == "poi-radio") | .version')"
+VERSION="$(cargo metadata --quiet --format-version 1 | jq -r '.packages[] | select(.name == "poi-radio") | .version')"
 
 if [[ -z "$VERSION" ]]; then
   echo "Usage: $0 <version>"
@@ -13,8 +13,8 @@ fi
 git-cliff -o CHANGELOG.md
 
 (
-  git add CHANGELOG.md Cargo.lock Cargo.toml \
-    && git commit -m "chore: release $VERSION"
+  git add CHANGELOG.md Cargo.lock Cargo.toml &&
+    git commit -m "chore: release $VERSION"
 ) || true
 
 # Publish to crates.io


### PR DESCRIPTION
### Description

This PR fixes the discrepancy between Docket and git tags, following the official semantic versioning style of `*.*.*`, without a `v` prefix.

1. Updates the release script to remove the "v" prefix
2. Updates the Docker build workflow file to trigger on tags matching `*.*.*` instead of `v*.*.*`

### Issue link (if applicable)
https://github.com/graphops/poi-radio/issues/120
